### PR TITLE
Feature/external editor for diffs

### DIFF
--- a/internal/application.go
+++ b/internal/application.go
@@ -20,7 +20,7 @@ func RunApplication(path string) {
 
 	var g run.Group
 	profiling.AddActor(&g, ctx)
-	ui.AddActor(&g, path)
+	ui.AddActor(&g, ctx, path)
 	addSignalHandlerActor(&g, cancel)
 
 	if err := g.Run(); err != nil {

--- a/internal/application.go
+++ b/internal/application.go
@@ -45,7 +45,8 @@ func addSignalHandlerActor(g *run.Group, cancel context.CancelFunc) {
 
 		return nil
 	}, func(err error) {
-		defer close(sig)
+		signal.Stop(sig) // Stop notifying for signals
+		close(sig)       // Then close the channel
 		cancel()
 	})
 }

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Configuration struct {
+	Diff      DiffConfig      `json:"diff"`
 	Profiling ProfilingConfig `json:"profiling"`
 }
 
@@ -43,6 +44,17 @@ func InitConfig(cfgFile string) {
 }
 
 func setDefaultValues() {
+	viper.SetDefault("Diff", DiffConfig{
+		Mode: DiffModeExternal,
+		External: ExternalDiffConfig{
+			Editor: ExternalDiffEditorConfig{
+				Path: "",
+			},
+		},
+	})
+	viper.SetDefault("Diff.Mode", DiffModeExternal)
+	viper.SetDefault("Diff.External.Editor.Path", "")
+
 	viper.SetDefault("Profiling", ProfilingConfig{
 		Enabled: false,
 		Host:    "localhost",
@@ -55,7 +67,7 @@ func setDefaultValues() {
 // DetectAndReadConfigFile detects the path of the first existing config file
 func DetectAndReadConfigFile() string {
 	_ = readInConfig()
-	return GetFilePath()
+	return viper.ConfigFileUsed()
 }
 
 // readInConfig reads and parses the config file

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -45,15 +45,14 @@ func InitConfig(cfgFile string) {
 
 func setDefaultValues() {
 	viper.SetDefault("Diff", DiffConfig{
-		Mode: DiffModeExternal,
-		External: ExternalDiffConfig{
-			Editor: ExternalDiffEditorConfig{
-				Path: "",
-			},
-		},
+		Mode:     DiffModeExternal,
+		External: nil,
 	})
 	viper.SetDefault("Diff.Mode", DiffModeExternal)
-	viper.SetDefault("Diff.External.Editor.Path", "")
+	viper.SetDefault("Diff.External", nil)
+	//viper.SetDefault("Diff.External.Path", "")
+	//viper.SetDefault("Diff.External.Args", []string{})
+	//viper.SetDefault("Diff.External.WrapInPager", false)
 
 	viper.SetDefault("Profiling", ProfilingConfig{
 		Enabled: false,

--- a/internal/configuration/diff.go
+++ b/internal/configuration/diff.go
@@ -8,14 +8,12 @@ const (
 )
 
 type DiffConfig struct {
-	Mode     DiffMode           `json:"mode"`
-	External ExternalDiffConfig `json:"external"`
+	Mode     DiffMode            `json:"mode"`
+	External *ExternalDiffConfig `json:"external,omitempty"`
 }
 
 type ExternalDiffConfig struct {
-	Editor ExternalDiffEditorConfig `json:"editor"`
-}
-
-type ExternalDiffEditorConfig struct {
-	Path string `json:"path"`
+	Path        string   `json:"path"`
+	Args        []string `json:"args"`
+	WrapInPager bool     `json:"wrapInPager"`
 }

--- a/internal/configuration/diff.go
+++ b/internal/configuration/diff.go
@@ -1,0 +1,21 @@
+package configuration
+
+type DiffMode string
+
+const (
+	DiffModeInternal DiffMode = "internal"
+	DiffModeExternal DiffMode = "external"
+)
+
+type DiffConfig struct {
+	Mode     DiffMode           `json:"mode"`
+	External ExternalDiffConfig `json:"external"`
+}
+
+type ExternalDiffConfig struct {
+	Editor ExternalDiffEditorConfig `json:"editor"`
+}
+
+type ExternalDiffEditorConfig struct {
+	Path string `json:"path"`
+}

--- a/internal/ui/actor.go
+++ b/internal/ui/actor.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"zfs-file-history/internal/logging"
 	"zfs-file-history/internal/zfs"
 
@@ -9,14 +10,16 @@ import (
 )
 
 // AddActor wires ZFS preload and UI lifecycle into the application run group.
-func AddActor(g *run.Group, path string) {
+func AddActor(g *run.Group, ctx context.Context, path string) {
 	g.Add(func() error {
 		logging.Info("Loading ZFS data...")
 		pterm.Info.Printfln("Loading ZFS data...")
 		zfs.RefreshZfsData()
 		pterm.Info.Printfln("Launching UI...")
 		logging.Info("Launching UI...")
-		return CreateUi(path, true).Run()
+
+		application := CreateUi(path, true)
+		return application.Run()
 	}, func(err error) {
 		if err != nil {
 			logging.Warning("Error stopping UI: %s", err.Error())

--- a/internal/ui/file_browser/external_diff_viewer.go
+++ b/internal/ui/file_browser/external_diff_viewer.go
@@ -44,6 +44,7 @@ var (
 	// Pagers
 	Delta = ExternalDiffViewerConfig{
 		Path:        "delta",
+		Args:        []string{"--line-numbers", "--hunk-header-style=omit"},
 		WrapInPager: true,
 	}
 

--- a/internal/ui/file_browser/external_diff_viewer.go
+++ b/internal/ui/file_browser/external_diff_viewer.go
@@ -108,6 +108,14 @@ func determineExternalDiffViewer(binaryPath string) (editorConfig *ExternalDiffV
 	return nil
 }
 
+func findEditorOption(path string, options []ExternalDiffViewerConfig) *ExternalDiffViewerConfig {
+	for _, option := range options {
+		if strings.HasSuffix(path, option.Path) {
+			return &option
+		}
+	}
+	return nil
+}
 func runExternalDiffEditor(application *tview.Application, editorConf ExternalDiffViewerConfig, snapshotFilePath string, realFilePath string) {
 	var args []string
 	args = append(args, editorConf.Args...)

--- a/internal/ui/file_browser/external_diff_viewer.go
+++ b/internal/ui/file_browser/external_diff_viewer.go
@@ -1,6 +1,14 @@
 package file_browser
 
-import "os/exec"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"zfs-file-history/internal/logging"
+
+	"github.com/rivo/tview"
+)
 
 type ExternalDiffViewerConfig struct {
 	Path        string
@@ -17,4 +25,115 @@ func (c ExternalDiffViewerConfig) computeRunArgs() []string {
 func (c ExternalDiffViewerConfig) IsAvailable() bool {
 	_, err := exec.LookPath(c.Path)
 	return err == nil
+}
+
+var (
+	// Editors
+	NVIM = ExternalDiffViewerConfig{
+		Path: "nvim",
+		Args: []string{"-d"},
+	}
+	VIMDIFF = ExternalDiffViewerConfig{
+		Path: "vimdiff",
+	}
+	KAK = ExternalDiffViewerConfig{
+		Path: "kak",
+		Args: []string{"-d"},
+	}
+
+	// Pagers
+	Delta = ExternalDiffViewerConfig{
+		Path:        "delta",
+		WrapInPager: true,
+	}
+
+	Difft = ExternalDiffViewerConfig{
+		Path: "difft",
+	}
+
+	GitDiff = ExternalDiffViewerConfig{
+		Path:        "git",
+		Args:        []string{"--paginate", "diff", "--no-index", "--color=always"},
+		WrapInPager: true,
+	}
+	Deff = ExternalDiffViewerConfig{
+		Path: "deff",
+	}
+
+	EditorOptions = []ExternalDiffViewerConfig{
+		NVIM,
+		KAK,
+		Delta,
+		Difft,
+		Deff,
+		//VIMDIFF,
+		GitDiff,
+	}
+)
+
+func determineExternalDiffViewer(editorPath string) (editorConfig *ExternalDiffViewerConfig) {
+	if editorPath != "" {
+		editorConfig = findEditorOption(editorPath, EditorOptions)
+		if editorConfig != nil {
+			return editorConfig
+		}
+
+		logging.Warning("Configured external editor '%s' is not recognized. Falling back to internal diff.", editorPath)
+	}
+
+	for _, editor := range EditorOptions {
+		if !editor.IsAvailable() {
+			continue
+		}
+
+		logging.Info("Using external diff viewer: %s", editor.Path)
+		return &editor
+	}
+
+	logging.Warning("No configured external diff viewer found on system. Checking EDITOR environment variable for fallback option.")
+
+	editorEnvValue := os.Getenv("EDITOR")
+	if editorEnvValue == "" {
+		logging.Error("EDITOR environment variable not set and no external editor path configured. Falling back to internal diff.")
+	} else {
+		editorConfig = findEditorOption(editorPath, EditorOptions)
+		if editorConfig == nil {
+			logging.Error("EDITOR environment variable is set to '%s' but it is not a recognized editor. Falling back to internal diff.", editorEnvValue)
+		} else {
+			return editorConfig
+		}
+	}
+
+	return nil
+}
+
+func runExternalDiffEditor(application *tview.Application, editorConf ExternalDiffViewerConfig, snapshotFilePath string, realFilePath string) {
+	var args []string
+	args = append(args, editorConf.Args...)
+	args = append(args, snapshotFilePath)
+	args = append(args, realFilePath)
+
+	var cmd *exec.Cmd
+	if editorConf.WrapInPager {
+		// pipe the output into "less -R" to make it blocking
+		editorCommandArgsString := strings.Join(editorConf.Args, " ")
+		editorCommand := fmt.Sprintf("%s %s '%s' '%s' | less -R", editorConf.Path, editorCommandArgsString, snapshotFilePath, realFilePath)
+		cmd = exec.Command("sh", "-c", editorCommand)
+	} else {
+		cmd = exec.Command(editorConf.Path, args...)
+	}
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	application.Suspend(func() {
+		runErr := cmd.Run()
+		if runErr != nil {
+			logging.Error("Error running external diff editor: %v", runErr)
+		}
+	})
+	// After suspend, ensure the tview application redraws itself
+	application.Sync()
+	application.Draw()
 }

--- a/internal/ui/file_browser/external_diff_viewer.go
+++ b/internal/ui/file_browser/external_diff_viewer.go
@@ -11,9 +11,9 @@ import (
 )
 
 type ExternalDiffViewerConfig struct {
-	Path        string
-	Args        []string
-	WrapInPager bool
+	Path        string   `json:"path"`
+	Args        []string `json:"args"`
+	WrapInPager bool     `json:"wrapInPager"`
 }
 
 func (c ExternalDiffViewerConfig) computeRunArgs() []string {
@@ -71,14 +71,14 @@ var (
 	}
 )
 
-func determineExternalDiffViewer(editorPath string) (editorConfig *ExternalDiffViewerConfig) {
-	if editorPath != "" {
-		editorConfig = findEditorOption(editorPath, EditorOptions)
+func determineExternalDiffViewer(binaryPath string) (editorConfig *ExternalDiffViewerConfig) {
+	if binaryPath != "" {
+		editorConfig = findEditorOption(binaryPath, EditorOptions)
 		if editorConfig != nil {
 			return editorConfig
 		}
 
-		logging.Warning("Configured external editor '%s' is not recognized. Falling back to internal diff.", editorPath)
+		logging.Warning("Configured external diff viewer '%s' not found on system. Checking other options.", binaryPath)
 	}
 
 	for _, editor := range EditorOptions {
@@ -96,7 +96,7 @@ func determineExternalDiffViewer(editorPath string) (editorConfig *ExternalDiffV
 	if editorEnvValue == "" {
 		logging.Error("EDITOR environment variable not set and no external editor path configured. Falling back to internal diff.")
 	} else {
-		editorConfig = findEditorOption(editorPath, EditorOptions)
+		editorConfig = findEditorOption(binaryPath, EditorOptions)
 		if editorConfig == nil {
 			logging.Error("EDITOR environment variable is set to '%s' but it is not a recognized editor. Falling back to internal diff.", editorEnvValue)
 		} else {

--- a/internal/ui/file_browser/external_diff_viewer.go
+++ b/internal/ui/file_browser/external_diff_viewer.go
@@ -1,0 +1,20 @@
+package file_browser
+
+import "os/exec"
+
+type ExternalDiffViewerConfig struct {
+	Path        string
+	Args        []string
+	WrapInPager bool
+}
+
+func (c ExternalDiffViewerConfig) computeRunArgs() []string {
+	args := make([]string, len(c.Args))
+	copy(args, c.Args)
+	return args
+}
+
+func (c ExternalDiffViewerConfig) IsAvailable() bool {
+	_, err := exec.LookPath(c.Path)
+	return err == nil
+}

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -633,12 +633,3 @@ func (fileBrowser *FileBrowserComponent) showError(err error) {
 func (fileBrowser *FileBrowserComponent) SetEventCallback(f func(event FileBrowserEvent)) {
 	fileBrowser.eventCallback = f
 }
-
-func findEditorOption(path string, options []ExternalDiffViewerConfig) *ExternalDiffViewerConfig {
-	for _, option := range options {
-		if strings.HasSuffix(path, option.Path) {
-			return &option
-		}
-	}
-	return nil
-}

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -562,11 +562,10 @@ func (fileBrowser *FileBrowserComponent) showDiff(selection *data.FileBrowserEnt
 			}
 		}
 
-		if editorConf == nil {
+		if editorConf != nil {
+			runExternalDiffEditor(fileBrowser.application, *editorConf, realFilePath, snapshotFilePath)
 			return
 		}
-		runExternalDiffEditor(fileBrowser.application, *editorConf, realFilePath, snapshotFilePath)
-		return
 	}
 
 	// Internal diff display (or fallback from external if no editor path)

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	path2 "path"
 	"slices"
 	"strings"
+	"zfs-file-history/internal/configuration"
 	"zfs-file-history/internal/data"
 	"zfs-file-history/internal/data/diff_state"
 	"zfs-file-history/internal/logging"
@@ -544,6 +546,21 @@ func (fileBrowser *FileBrowserComponent) showDiff(selection *data.FileBrowserEnt
 	if selection == nil || snapshot == nil {
 		return
 	}
+
+	realFilePath := selection.RealFile.Path
+	snapshotFilePath := snapshot.Snapshot.GetSnapshotPath(selection.RealFile.Path)
+
+	if configuration.CurrentConfig.Diff.Mode == configuration.DiffModeExternal {
+		editorPath := configuration.CurrentConfig.Diff.External.Editor.Path
+		editorConf := fileBrowser.determineExternalDiffViewer(editorPath)
+		if editorConf == nil {
+			return
+		}
+		fileBrowser.runExternalDiffEditor(*editorConf, realFilePath, snapshotFilePath)
+		return
+	}
+
+	// Internal diff display (or fallback from external if no editor path)
 	d := dialog.NewFileDiffDialog(fileBrowser.application, selection, snapshot)
 	fileBrowser.showDialog(d, func(action dialog.DialogActionId) bool {
 		switch action {
@@ -607,4 +624,132 @@ func (fileBrowser *FileBrowserComponent) showError(err error) {
 
 func (fileBrowser *FileBrowserComponent) SetEventCallback(f func(event FileBrowserEvent)) {
 	fileBrowser.eventCallback = f
+}
+
+var (
+	// Editors
+	NVIM = ExternalDiffViewerConfig{
+		Path: "nvim",
+		Args: []string{"-d"},
+	}
+	VIMDIFF = ExternalDiffViewerConfig{
+		Path: "vimdiff",
+	}
+	KAK = ExternalDiffViewerConfig{
+		Path: "kak",
+		Args: []string{"-d"},
+	}
+
+	// Pagers
+	Delta = ExternalDiffViewerConfig{
+		Path: "delta",
+	}
+
+	Difftastic = ExternalDiffViewerConfig{
+		Path: "difftastic",
+	}
+
+	Difft = ExternalDiffViewerConfig{
+		Path: "difft",
+	}
+
+	GitDiff = ExternalDiffViewerConfig{
+		Path:        "git",
+		Args:        []string{"--paginate", "diff", "--no-index", "--color=always"},
+		WrapInPager: true,
+	}
+	Difi = ExternalDiffViewerConfig{
+		Path: "difi",
+	}
+	Deff = ExternalDiffViewerConfig{
+		Path: "deff",
+	}
+
+	EditorOptions = []ExternalDiffViewerConfig{
+		NVIM,
+		KAK,
+		Delta,
+		Difftastic,
+		Difft,
+		Difi,
+		Deff,
+		VIMDIFF,
+		GitDiff,
+	}
+)
+
+func (fileBrowser *FileBrowserComponent) determineExternalDiffViewer(editorPath string) (editorConfig *ExternalDiffViewerConfig) {
+	if editorPath != "" {
+		editorConfig = findEditorOption(editorPath, EditorOptions)
+		if editorConfig != nil {
+			return editorConfig
+		}
+
+		logging.Warning("Configured external editor '%s' is not recognized. Falling back to internal diff.", editorPath)
+	}
+
+	for _, editor := range EditorOptions {
+		if !editor.IsAvailable() {
+			continue
+		}
+
+		logging.Info("Using external diff viewer: %s", editor.Path)
+		return &editor
+	}
+
+	logging.Warning("No configured external diff viewer found on system. Checking EDITOR environment variable for fallback option.")
+
+	editorEnvValue := os.Getenv("EDITOR")
+	if editorEnvValue == "" {
+		logging.Error("EDITOR environment variable not set and no external editor path configured. Falling back to internal diff.")
+	} else {
+		editorConfig = findEditorOption(editorPath, EditorOptions)
+		if editorConfig == nil {
+			logging.Error("EDITOR environment variable is set to '%s' but it is not a recognized editor. Falling back to internal diff.", editorEnvValue)
+		} else {
+			return editorConfig
+		}
+	}
+
+	return nil
+}
+
+func findEditorOption(path string, options []ExternalDiffViewerConfig) *ExternalDiffViewerConfig {
+	for _, option := range options {
+		if strings.HasSuffix(path, option.Path) {
+			return &option
+		}
+	}
+	return nil
+}
+
+func (fileBrowser *FileBrowserComponent) runExternalDiffEditor(editorConf ExternalDiffViewerConfig, snapshotFilePath string, realFilePath string) {
+	var args []string
+	args = append(args, editorConf.Args...)
+	args = append(args, snapshotFilePath)
+	args = append(args, realFilePath)
+
+	var cmd *exec.Cmd
+	if editorConf.WrapInPager {
+		// pipe the output into "less -R" to make it blocking
+		editorCommandArgsString := strings.Join(editorConf.Args, " ")
+		editorCommand := fmt.Sprintf("%s %s '%s' '%s' | less -R", editorConf.Path, editorCommandArgsString, snapshotFilePath, realFilePath)
+		cmd = exec.Command("sh", "-c", editorCommand)
+	} else {
+		cmd = exec.Command(editorConf.Path, args...)
+	}
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	fileBrowser.application.Suspend(func() {
+		runErr := cmd.Run()
+		if runErr != nil {
+			logging.Error("Error running external diff editor: %v", runErr)
+		}
+	})
+	// After suspend, ensure the tview application redraws itself
+	fileBrowser.application.Sync()
+	fileBrowser.application.Draw()
 }

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -642,11 +642,8 @@ var (
 
 	// Pagers
 	Delta = ExternalDiffViewerConfig{
-		Path: "delta",
-	}
-
-	Difftastic = ExternalDiffViewerConfig{
-		Path: "difftastic",
+		Path:        "delta",
+		WrapInPager: true,
 	}
 
 	Difft = ExternalDiffViewerConfig{
@@ -658,9 +655,6 @@ var (
 		Args:        []string{"--paginate", "diff", "--no-index", "--color=always"},
 		WrapInPager: true,
 	}
-	Difi = ExternalDiffViewerConfig{
-		Path: "difi",
-	}
 	Deff = ExternalDiffViewerConfig{
 		Path: "deff",
 	}
@@ -669,11 +663,9 @@ var (
 		NVIM,
 		KAK,
 		Delta,
-		Difftastic,
 		Difft,
-		Difi,
 		Deff,
-		VIMDIFF,
+		//VIMDIFF,
 		GitDiff,
 	}
 )

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	path2 "path"
 	"slices"
 	"strings"
@@ -552,11 +551,11 @@ func (fileBrowser *FileBrowserComponent) showDiff(selection *data.FileBrowserEnt
 
 	if configuration.CurrentConfig.Diff.Mode == configuration.DiffModeExternal {
 		editorPath := configuration.CurrentConfig.Diff.External.Editor.Path
-		editorConf := fileBrowser.determineExternalDiffViewer(editorPath)
+		editorConf := determineExternalDiffViewer(editorPath)
 		if editorConf == nil {
 			return
 		}
-		fileBrowser.runExternalDiffEditor(*editorConf, realFilePath, snapshotFilePath)
+		runExternalDiffEditor(fileBrowser.application, *editorConf, realFilePath, snapshotFilePath)
 		return
 	}
 
@@ -626,86 +625,6 @@ func (fileBrowser *FileBrowserComponent) SetEventCallback(f func(event FileBrows
 	fileBrowser.eventCallback = f
 }
 
-var (
-	// Editors
-	NVIM = ExternalDiffViewerConfig{
-		Path: "nvim",
-		Args: []string{"-d"},
-	}
-	VIMDIFF = ExternalDiffViewerConfig{
-		Path: "vimdiff",
-	}
-	KAK = ExternalDiffViewerConfig{
-		Path: "kak",
-		Args: []string{"-d"},
-	}
-
-	// Pagers
-	Delta = ExternalDiffViewerConfig{
-		Path:        "delta",
-		WrapInPager: true,
-	}
-
-	Difft = ExternalDiffViewerConfig{
-		Path: "difft",
-	}
-
-	GitDiff = ExternalDiffViewerConfig{
-		Path:        "git",
-		Args:        []string{"--paginate", "diff", "--no-index", "--color=always"},
-		WrapInPager: true,
-	}
-	Deff = ExternalDiffViewerConfig{
-		Path: "deff",
-	}
-
-	EditorOptions = []ExternalDiffViewerConfig{
-		NVIM,
-		KAK,
-		Delta,
-		Difft,
-		Deff,
-		//VIMDIFF,
-		GitDiff,
-	}
-)
-
-func (fileBrowser *FileBrowserComponent) determineExternalDiffViewer(editorPath string) (editorConfig *ExternalDiffViewerConfig) {
-	if editorPath != "" {
-		editorConfig = findEditorOption(editorPath, EditorOptions)
-		if editorConfig != nil {
-			return editorConfig
-		}
-
-		logging.Warning("Configured external editor '%s' is not recognized. Falling back to internal diff.", editorPath)
-	}
-
-	for _, editor := range EditorOptions {
-		if !editor.IsAvailable() {
-			continue
-		}
-
-		logging.Info("Using external diff viewer: %s", editor.Path)
-		return &editor
-	}
-
-	logging.Warning("No configured external diff viewer found on system. Checking EDITOR environment variable for fallback option.")
-
-	editorEnvValue := os.Getenv("EDITOR")
-	if editorEnvValue == "" {
-		logging.Error("EDITOR environment variable not set and no external editor path configured. Falling back to internal diff.")
-	} else {
-		editorConfig = findEditorOption(editorPath, EditorOptions)
-		if editorConfig == nil {
-			logging.Error("EDITOR environment variable is set to '%s' but it is not a recognized editor. Falling back to internal diff.", editorEnvValue)
-		} else {
-			return editorConfig
-		}
-	}
-
-	return nil
-}
-
 func findEditorOption(path string, options []ExternalDiffViewerConfig) *ExternalDiffViewerConfig {
 	for _, option := range options {
 		if strings.HasSuffix(path, option.Path) {
@@ -713,35 +632,4 @@ func findEditorOption(path string, options []ExternalDiffViewerConfig) *External
 		}
 	}
 	return nil
-}
-
-func (fileBrowser *FileBrowserComponent) runExternalDiffEditor(editorConf ExternalDiffViewerConfig, snapshotFilePath string, realFilePath string) {
-	var args []string
-	args = append(args, editorConf.Args...)
-	args = append(args, snapshotFilePath)
-	args = append(args, realFilePath)
-
-	var cmd *exec.Cmd
-	if editorConf.WrapInPager {
-		// pipe the output into "less -R" to make it blocking
-		editorCommandArgsString := strings.Join(editorConf.Args, " ")
-		editorCommand := fmt.Sprintf("%s %s '%s' '%s' | less -R", editorConf.Path, editorCommandArgsString, snapshotFilePath, realFilePath)
-		cmd = exec.Command("sh", "-c", editorCommand)
-	} else {
-		cmd = exec.Command(editorConf.Path, args...)
-	}
-
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	fileBrowser.application.Suspend(func() {
-		runErr := cmd.Run()
-		if runErr != nil {
-			logging.Error("Error running external diff editor: %v", runErr)
-		}
-	})
-	// After suspend, ensure the tview application redraws itself
-	fileBrowser.application.Sync()
-	fileBrowser.application.Draw()
 }

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -550,8 +550,18 @@ func (fileBrowser *FileBrowserComponent) showDiff(selection *data.FileBrowserEnt
 	snapshotFilePath := snapshot.Snapshot.GetSnapshotPath(selection.RealFile.Path)
 
 	if configuration.CurrentConfig.Diff.Mode == configuration.DiffModeExternal {
-		editorPath := configuration.CurrentConfig.Diff.External.Editor.Path
-		editorConf := determineExternalDiffViewer(editorPath)
+		externalConf := configuration.CurrentConfig.Diff.External
+		var editorConf *ExternalDiffViewerConfig
+		if externalConf == nil {
+			editorConf = determineExternalDiffViewer("")
+		} else {
+			editorConf = &ExternalDiffViewerConfig{
+				Path:        externalConf.Path,
+				Args:        externalConf.Args,
+				WrapInPager: externalConf.WrapInPager,
+			}
+		}
+
 		if editorConf == nil {
 			return
 		}

--- a/internal/ui/theme/dark.go
+++ b/internal/ui/theme/dark.go
@@ -11,8 +11,8 @@ var (
 	Primary   = tcell.ColorTeal
 	Secondary = tcell.ColorDarkOliveGreen
 
-	OnPrimary   = tcell.ColorWhite
-	OnSecondary = tcell.ColorBlack
+	OnPrimary   = tcell.ColorBlack
+	OnSecondary = tcell.ColorWhite
 )
 
 var (

--- a/zfs-file-history.yaml
+++ b/zfs-file-history.yaml
@@ -1,3 +1,6 @@
+diff:
+  mode: external
+
 profiling:
   # Whether to enable the profiling webserver
   enabled: false


### PR DESCRIPTION
## Summary

This PR introduces configurable external diff tooling to improve the file comparison experience in `zfs-file-history`. Users can now launch diffs in external applications such as `delta` or `difftastic` instead of relying solely on the built-in viewer.

## Changes

- Add configuration support for external diff editors/viewers
- Automatic detection of locally available diff tools
- Allow user configuration through `zfs-file-history.yaml`

## Motivation

While the built-in diff viewer works well for simple use cases, there are already way more advanced diff tools with syntax highlighting, side-by-side rendering, and better terminal UX. This feature makes it possible to integrate those tools directly into the snapshot history workflow.

## Screenshot

<img width="1190" height="2133" alt="image" src="https://github.com/user-attachments/assets/a32a8be9-7ab6-489f-830a-9f42d7fe5dcc" />

## Example Configuration

```yaml
diff:
  mode: external
  external:
    enabled: true
    path: delta
    args:
      - "--side-by-side"
    wrapInPager: true