### PR TITLE
Feature/improve list selection

### DIFF
--- a/internal/ui/dialog/file_action_dialog.go
+++ b/internal/ui/dialog/file_action_dialog.go
@@ -67,20 +67,23 @@ func buildFileDialogOptions(file *data.FileBrowserEntry, diffBinAvailable bool) 
 
 	if file.HasReal() {
 		dialogOptions = slices.Insert(dialogOptions, 0, &DialogOption{
-			Id:   FileDialogDeleteDialogActionId,
-			Name: fmt.Sprintf("Delete '%s'", file.RealFile.Name),
+			Id:       FileDialogDeleteDialogActionId,
+			Name:     fmt.Sprintf("🗑 Delete '%s'", file.RealFile.Name),
+			Severity: DialogSeverityDanger,
 		})
 	}
 
 	if file.HasSnapshot() {
 		if file.Type == data.Directory {
 			dialogOptions = slices.Insert(dialogOptions, 0, &DialogOption{
-				Id:   FileDialogRestoreFileActionId,
-				Name: "Restore directory only",
+				Id:       FileDialogRestoreFileActionId,
+				Name:     "📁 Restore directory only",
+				Severity: DialogSeverityWarning,
 			})
 			dialogOptions = slices.Insert(dialogOptions, 0, &DialogOption{
-				Id:   FileDialogRestoreRecursiveDialogActionId,
-				Name: "Restore directory recursively",
+				Id:       FileDialogRestoreRecursiveDialogActionId,
+				Name:     "🌳 Restore directory recursively",
+				Severity: DialogSeverityDanger,
 			})
 		}
 
@@ -88,19 +91,20 @@ func buildFileDialogOptions(file *data.FileBrowserEntry, diffBinAvailable bool) 
 			if diffBinAvailable && file.DiffState == diff_state.Modified {
 				dialogOptions = slices.Insert(dialogOptions, 0, &DialogOption{
 					Id:   FileDialogShowDiffActionId,
-					Name: "Show diff",
+					Name: "🔍 Show diff",
 				})
 			}
 			dialogOptions = slices.Insert(dialogOptions, 1, &DialogOption{
-				Id:   FileDialogRestoreFileActionId,
-				Name: "Restore file",
+				Id:       FileDialogRestoreFileActionId,
+				Name:     "♻️ Restore file",
+				Severity: DialogSeverityWarning,
 			})
 		}
 	}
 
 	dialogOptions = slices.Insert(dialogOptions, 0, &DialogOption{
 		Id:   FileDialogCreateSnapshotDialogActionId,
-		Name: "Create Snapshot",
+		Name: "📸 Create Snapshot",
 	})
 
 	return ensureDialogCloseIsLast(dialogOptions)

--- a/internal/ui/dialog/file_action_dialog.go
+++ b/internal/ui/dialog/file_action_dialog.go
@@ -68,7 +68,7 @@ func buildFileDialogOptions(file *data.FileBrowserEntry, diffBinAvailable bool) 
 	if file.HasReal() {
 		dialogOptions = slices.Insert(dialogOptions, 0, &DialogOption{
 			Id:       FileDialogDeleteDialogActionId,
-			Name:     fmt.Sprintf("🗑 Delete '%s'", file.RealFile.Name),
+			Name:     fmt.Sprintf("🗑  Delete '%s'", file.RealFile.Name),
 			Severity: DialogSeverityDanger,
 		})
 	}

--- a/internal/ui/dialog/snapshot_action_dialog.go
+++ b/internal/ui/dialog/snapshot_action_dialog.go
@@ -44,15 +44,17 @@ func (d *SnapshotActionDialog) createLayout() {
 	dialogOptions := []*DialogOption{
 		{
 			Id:   SnapshotDialogCreateSnapshotActionId,
-			Name: "Create Snapshot",
+			Name: "📸 Create Snapshot",
 		},
 		{
-			Id:   SnapshotDialogDestroySnapshotActionId,
-			Name: fmt.Sprintf("Destroy '%s'", d.snapshot.Snapshot.Name),
+			Id:       SnapshotDialogDestroySnapshotActionId,
+			Name:     fmt.Sprintf("💥 Destroy '%s'", d.snapshot.Snapshot.Name),
+			Severity: DialogSeverityDanger,
 		},
 		{
-			Id:   SnapshotDialogDestroySnapshotRecursivelyActionId,
-			Name: fmt.Sprintf("Destroy (recursive) '%s'", d.snapshot.Snapshot.Name),
+			Id:       SnapshotDialogDestroySnapshotRecursivelyActionId,
+			Name:     fmt.Sprintf("💥 Destroy (recursive) '%s'", d.snapshot.Snapshot.Name),
+			Severity: DialogSeverityDanger,
 		},
 		{
 			Id:   DialogCloseActionId,

--- a/internal/ui/dialog/util.go
+++ b/internal/ui/dialog/util.go
@@ -8,8 +8,19 @@ import (
 	"github.com/rivo/tview"
 )
 
+type DialogActionId int
+
 const (
 	DialogCloseActionId DialogActionId = iota
+)
+
+type DialogSeverity int
+
+const (
+	DialogSeverityNeutral DialogSeverity = iota
+	DialogSeveritySafe
+	DialogSeverityWarning
+	DialogSeverityDanger
 )
 
 type Dialog interface {
@@ -18,11 +29,10 @@ type Dialog interface {
 	GetActionChannel() <-chan DialogActionId
 }
 
-type DialogActionId int
-
 type DialogOption struct {
-	Id   DialogActionId
-	Name string
+	Id       DialogActionId
+	Name     string
+	Severity DialogSeverity
 }
 
 // buildConfirmDialogOptions creates a standard [confirm, cancel] option list.
@@ -83,9 +93,20 @@ func createOptionTable(application *tview.Application, options []*DialogOption, 
 	})
 
 	for row, option := range options {
+		var textColor tcell.Color
+		switch option.Severity {
+		case DialogSeverityNeutral:
+			textColor = tcell.ColorWhite
+		case DialogSeveritySafe:
+			textColor = tcell.ColorWhite
+		case DialogSeverityWarning:
+			textColor = tcell.ColorYellow
+		case DialogSeverityDanger:
+			textColor = tcell.ColorRed
+		}
 		optionTable.SetCell(row, 0,
 			tview.NewTableCell(option.Name).
-				SetTextColor(tcell.ColorWhite).
+				SetTextColor(textColor).
 				SetAlign(tview.AlignLeft).
 				SetExpansion(1),
 		)

--- a/internal/ui/table/table_component.go
+++ b/internal/ui/table/table_component.go
@@ -139,13 +139,6 @@ func (c *RowSelectionTable[T]) createLayout() {
 		}
 		key := event.Key()
 
-		if c.HasMultiSelection() {
-			switch key {
-			case tcell.KeyEscape:
-				c.ClearMultiSelection()
-			}
-		}
-
 		// current selection is on HEADER row
 		if c.GetSelectedEntry() == nil {
 			switch key {
@@ -162,10 +155,35 @@ func (c *RowSelectionTable[T]) createLayout() {
 			}
 		}
 
-		// current selection is on DATA row
-		if event.Rune() == SpaceRune && c.multiSelectEnabled {
-			currentEntry := c.GetSelectedEntry()
-			c.toggleMultiSelection(currentEntry)
+		if c.HasMultiSelection() {
+			switch key {
+			case tcell.KeyEscape:
+				c.ClearMultiSelection()
+			}
+		}
+
+		if c.multiSelectEnabled {
+			if event.Modifiers()&tcell.ModShift != 0 {
+				switch key {
+				case tcell.KeyUp:
+					c.addToMultiSelection(c.GetSelectedEntry())
+					c.Up()
+					c.addToMultiSelection(c.GetSelectedEntry())
+					return nil
+				case tcell.KeyDown:
+					c.addToMultiSelection(c.GetSelectedEntry())
+					c.Down()
+					c.addToMultiSelection(c.GetSelectedEntry())
+					return nil
+				default:
+				}
+			}
+
+			// current selection is on DATA row
+			if event.Rune() == SpaceRune {
+				currentEntry := c.GetSelectedEntry()
+				c.toggleMultiSelection(currentEntry)
+			}
 		}
 
 		return event
@@ -421,5 +439,21 @@ func (c *RowSelectionTable[T]) cleanupMultiSelection() {
 		if !slices.Contains(currentEntryIds, entryId) {
 			delete(c.multiSelectionEntryMap, entryId)
 		}
+	}
+}
+
+// Up moves the current selection up one row
+func (c *RowSelectionTable[T]) Up() {
+	row, col := c.layout.GetSelection()
+	if row > 0 {
+		c.layout.Select(row-1, col)
+	}
+}
+
+// Down moves the current selection down one row
+func (c *RowSelectionTable[T]) Down() {
+	row, col := c.layout.GetSelection()
+	if row < len(c.entries) {
+		c.layout.Select(row+1, col)
 	}
 }


### PR DESCRIPTION
## Summary

This PR improves list interaction and dialog UX in the terminal UI.

### Changes

- Add range selection support using `Shift + Up/Down`
  - Enables selecting multiple entries more efficiently
  - Improves keyboard-driven workflows and bulk operations

- Add severity levels and icons to dialog options
  - Makes dialogs easier to scan visually
  - Provides clearer contextual feedback for warnings, errors, and informational prompts

## Motivation

Navigating and operating on larger snapshot/file lists was previously cumbersome when using only keyboard controls. This update improves usability and accessibility by introducing familiar range-selection behavior and more expressive dialogs.

## Screenshot

<img width="491" height="317" alt="image" src="https://github.com/user-attachments/assets/f84629ef-533e-4060-a596-19d2284998f8" />
