### PR TITLE
Feature/keyboard shortcuts

### DIFF
--- a/internal/ui/dialog/confirm_dialog_options_test.go
+++ b/internal/ui/dialog/confirm_dialog_options_test.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"testing"
+	"zfs-file-history/internal/ui/localization"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -9,20 +10,20 @@ import (
 func TestBuildConfirmDialogOptions_WithConfirmAction(t *testing.T) {
 	t.Parallel()
 
-	options := buildConfirmDialogOptions(DeleteFileDialogDeleteFileActionId, "Delete", true)
+	options := buildConfirmDialogOptions(DeleteFileDialogDeleteFileActionId, localization.LocalizationCommonDelete, true, DialogSeverityDanger)
 
 	assert.Equal(t,
 		[]DialogActionId{DeleteFileDialogDeleteFileActionId, DialogCloseActionId},
 		optionIds(options),
 	)
-	assert.Equal(t, "Delete", options[0].Name)
-	assert.Equal(t, "Cancel", options[1].Name)
+	assert.Equal(t, localization.LocalizationCommonDelete, options[0].Name)
+	assert.Equal(t, localization.LocalizationCommonCancel, options[1].Name)
 }
 
 func TestBuildConfirmDialogOptions_WithoutConfirmAction(t *testing.T) {
 	t.Parallel()
 
-	options := buildConfirmDialogOptions(DeleteFileDialogDeleteFileActionId, "Delete", false)
+	options := buildConfirmDialogOptions(DeleteFileDialogDeleteFileActionId, localization.LocalizationCommonDelete, false, DialogSeverityDanger)
 
 	assert.Equal(t, []DialogActionId{DialogCloseActionId}, optionIds(options))
 	assert.Equal(t, "Cancel", options[0].Name)

--- a/internal/ui/dialog/delete_file_dialog.go
+++ b/internal/ui/dialog/delete_file_dialog.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"zfs-file-history/internal/data"
+	"zfs-file-history/internal/ui/localization"
 	"zfs-file-history/internal/ui/util"
 
 	"github.com/rivo/tview"
@@ -34,12 +35,12 @@ func NewDeleteFileDialog(application *tview.Application, file *data.FileBrowserE
 }
 
 func (d *DeleteFileDialog) createLayout() {
-	dialogTitle := " Delete File "
+	dialogTitle := " 🗑️ Delete File "
 
 	textDescription := fmt.Sprintf("Delete '%s'?", d.file.Name)
 	textDescriptionView := tview.NewTextView().SetText(textDescription)
 
-	dialogOptions := buildConfirmDialogOptions(DeleteFileDialogDeleteFileActionId, "Delete", d.file.HasReal())
+	dialogOptions := buildConfirmDialogOptions(DeleteFileDialogDeleteFileActionId, localization.LocalizationCommonDelete, d.file.HasReal(), DialogSeverityDanger)
 
 	optionTable := createOptionTable(d.application, dialogOptions, d.selectAction)
 

--- a/internal/ui/dialog/delete_snapshot_dialog.go
+++ b/internal/ui/dialog/delete_snapshot_dialog.go
@@ -34,12 +34,12 @@ func NewDeleteSnapshotDialog(application *tview.Application, snapshot *data.Snap
 }
 
 func (d *DeleteSnapshotDialog) createLayout() {
-	dialogTitle := " Destroy Snapshot "
+	dialogTitle := " 💥 Destroy Snapshot "
 
 	textDescription := fmt.Sprintf("Destroy '%s'?", d.snapshot.Snapshot.Name)
 	textDescriptionView := tview.NewTextView().SetText(textDescription)
 
-	dialogOptions := buildConfirmDialogOptions(DeleteSnapshotDialogDeleteSnapshotActionId, "Destroy", true)
+	dialogOptions := buildConfirmDialogOptions(DeleteSnapshotDialogDeleteSnapshotActionId, "Destroy", true, DialogSeverityDanger)
 
 	optionTable := createOptionTable(d.application, dialogOptions, d.selectAction)
 

--- a/internal/ui/dialog/dialog_close_action_test.go
+++ b/internal/ui/dialog/dialog_close_action_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 	"zfs-file-history/internal/data"
+	"zfs-file-history/internal/ui/localization"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -11,7 +12,7 @@ import (
 func TestSnapshotActionDialog_SelectCloseOption_EmitsCloseAction(t *testing.T) {
 	d := &SnapshotActionDialog{actionChannel: make(chan DialogActionId, 1)}
 
-	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: "Close"})
+	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: localization.LocalizationCommonClose})
 
 	assertDialogActionEmitted(t, d.actionChannel, DialogCloseActionId)
 }
@@ -19,7 +20,7 @@ func TestSnapshotActionDialog_SelectCloseOption_EmitsCloseAction(t *testing.T) {
 func TestDeleteFileDialog_SelectCancelOption_EmitsCloseAction(t *testing.T) {
 	d := &DeleteFileDialog{actionChannel: make(chan DialogActionId, 1)}
 
-	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: "Cancel"})
+	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: localization.LocalizationCommonCancel})
 
 	assertDialogActionEmitted(t, d.actionChannel, DialogCloseActionId)
 }
@@ -27,7 +28,7 @@ func TestDeleteFileDialog_SelectCancelOption_EmitsCloseAction(t *testing.T) {
 func TestDeleteSnapshotDialog_SelectCancelOption_EmitsCloseAction(t *testing.T) {
 	d := &DeleteSnapshotDialog{actionChannel: make(chan DialogActionId, 1)}
 
-	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: "Cancel"})
+	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: localization.LocalizationCommonCancel})
 
 	assertDialogActionEmitted(t, d.actionChannel, DialogCloseActionId)
 }
@@ -35,7 +36,7 @@ func TestDeleteSnapshotDialog_SelectCancelOption_EmitsCloseAction(t *testing.T) 
 func TestMultiSnapshotActionDialog_SelectCloseOption_EmitsCloseAction(t *testing.T) {
 	d := &MultiSnapshotActionDialog{actionChannel: make(chan DialogActionId, 1)}
 
-	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: "Close"})
+	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: localization.LocalizationCommonClose})
 
 	assertDialogActionEmitted(t, d.actionChannel, DialogCloseActionId)
 }
@@ -46,7 +47,7 @@ func TestSnapshotActionDialog_SelectCloseOption_DoesNotEmitOtherAction(t *testin
 		snapshot:      &data.SnapshotBrowserEntry{},
 	}
 
-	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: "Close"})
+	d.selectAction(&DialogOption{Id: DialogCloseActionId, Name: localization.LocalizationCommonClose})
 
 	assertDialogActionEmitted(t, d.actionChannel, DialogCloseActionId)
 	assertNoMoreDialogActions(t, d.actionChannel)

--- a/internal/ui/dialog/file_action_dialog.go
+++ b/internal/ui/dialog/file_action_dialog.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"zfs-file-history/internal/data"
 	"zfs-file-history/internal/data/diff_state"
+	"zfs-file-history/internal/ui/localization"
 	"zfs-file-history/internal/ui/util"
 
 	"github.com/rivo/tview"
@@ -42,7 +43,7 @@ func NewFileActionDialog(application *tview.Application, file *data.FileBrowserE
 }
 
 func (d *FileActionDialog) createLayout() {
-	dialogTitle := " Select Action "
+	dialogTitle := localization.LocalizationSelectActionDialogTitle
 
 	textDescription := fmt.Sprintf("What do you want to do with '%s'?", d.file.Name)
 	textDescriptionView := tview.NewTextView().SetText(textDescription)
@@ -62,7 +63,7 @@ func (d *FileActionDialog) createLayout() {
 func buildFileDialogOptions(file *data.FileBrowserEntry, diffBinAvailable bool) []*DialogOption {
 	dialogOptions := []*DialogOption{{
 		Id:   DialogCloseActionId,
-		Name: "Close",
+		Name: localization.LocalizationCommonClose,
 	}}
 
 	if file.HasReal() {

--- a/internal/ui/dialog/file_diff_dialog.go
+++ b/internal/ui/dialog/file_diff_dialog.go
@@ -38,7 +38,7 @@ func NewFileDiffDialog(application *tview.Application, file *data.FileBrowserEnt
 }
 
 func (d *FileDiffDialog) createLayout() {
-	dialogTitle := " File Diff "
+	dialogTitle := " 🔍 File Diff "
 
 	realFilePath := d.file.RealFile.Path
 	snapshotFilePath := d.snapshot.Snapshot.GetSnapshotPath(d.file.RealFile.Path)

--- a/internal/ui/dialog/help_dialog.go
+++ b/internal/ui/dialog/help_dialog.go
@@ -52,7 +52,7 @@ func (p *HelpPage) createLayout() {
 		setHelpTableRow(helpTable, row, entry)
 	}
 
-	p.layout = createModal(" Help ", helpTable, 60, 14)
+	p.layout = createModal(" ℹ️ Help ", helpTable, 60, 14)
 }
 
 func setHelpTableRow(helpTable *tview.Table, row int, entry *TableEntry) {

--- a/internal/ui/dialog/restore_file_progress_dialog.go
+++ b/internal/ui/dialog/restore_file_progress_dialog.go
@@ -47,7 +47,7 @@ func NewRestoreFileProgressDialog(application *tview.Application, fileSelection 
 }
 
 func (d *RestoreFileProgressDialog) createLayout() {
-	dialogTitle := "Restore"
+	dialogTitle := " ♻️ Restore "
 
 	fileToRestore := d.fileSelection.SnapshotFiles[0]
 

--- a/internal/ui/dialog/snapshot_action_dialog.go
+++ b/internal/ui/dialog/snapshot_action_dialog.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"zfs-file-history/internal/data"
+	"zfs-file-history/internal/ui/localization"
 	"zfs-file-history/internal/ui/util"
 
 	"github.com/rivo/tview"
@@ -36,7 +37,7 @@ func NewSnapshotActionDialog(application *tview.Application, snapshot *data.Snap
 }
 
 func (d *SnapshotActionDialog) createLayout() {
-	dialogTitle := " Select Action "
+	dialogTitle := localization.LocalizationSelectActionDialogTitle
 
 	textDescription := fmt.Sprintf("What do you want to do with '%s'?", d.snapshot.Snapshot.Name)
 	textDescriptionView := tview.NewTextView().SetText(textDescription)
@@ -58,7 +59,7 @@ func (d *SnapshotActionDialog) createLayout() {
 		},
 		{
 			Id:   DialogCloseActionId,
-			Name: "Close",
+			Name: localization.LocalizationCommonClose,
 		},
 	}
 

--- a/internal/ui/dialog/snapshot_multi_action_dialog.go
+++ b/internal/ui/dialog/snapshot_multi_action_dialog.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"zfs-file-history/internal/data"
+	"zfs-file-history/internal/ui/localization"
 	"zfs-file-history/internal/ui/util"
 
 	"github.com/rivo/tview"
@@ -36,7 +37,7 @@ func NewMultiSnapshotActionDialog(application *tview.Application, snapshots []*d
 }
 
 func (d *MultiSnapshotActionDialog) createLayout() {
-	dialogTitle := " Select Action "
+	dialogTitle := localization.LocalizationSelectActionDialogTitle
 
 	snapshotNames := make([]string, 0)
 	for _, snapshot := range d.snapshots {
@@ -48,12 +49,14 @@ func (d *MultiSnapshotActionDialog) createLayout() {
 
 	dialogOptions := []*DialogOption{
 		{
-			Id:   MultiSnapshotDialogDestroySnapshotActionId,
-			Name: "Destroy all",
+			Id:       MultiSnapshotDialogDestroySnapshotActionId,
+			Name:     "💥 Destroy all",
+			Severity: DialogSeverityDanger,
 		},
 		{
-			Id:   MultiSnapshotDialogDestroySnapshotRecursivelyActionId,
-			Name: "Destroy all (recursive)",
+			Id:       MultiSnapshotDialogDestroySnapshotRecursivelyActionId,
+			Name:     "💥 Destroy all (recursive)",
+			Severity: DialogSeverityDanger,
 		},
 		{
 			Id:   MultiSnapshotDialogClearSelectionActionId,
@@ -61,7 +64,7 @@ func (d *MultiSnapshotActionDialog) createLayout() {
 		},
 		{
 			Id:   DialogCloseActionId,
-			Name: "Close",
+			Name: localization.LocalizationCommonClose,
 		},
 	}
 

--- a/internal/ui/dialog/util.go
+++ b/internal/ui/dialog/util.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"slices"
+	"zfs-file-history/internal/ui/localization"
 	uiutil "zfs-file-history/internal/ui/util"
 
 	"github.com/gdamore/tcell/v2"
@@ -36,15 +37,21 @@ type DialogOption struct {
 }
 
 // buildConfirmDialogOptions creates a standard [confirm, cancel] option list.
-func buildConfirmDialogOptions(confirmActionId DialogActionId, confirmLabel string, includeConfirm bool) []*DialogOption {
+func buildConfirmDialogOptions(
+	confirmActionId DialogActionId,
+	confirmLabel string,
+	includeConfirm bool,
+	severity DialogSeverity,
+) []*DialogOption {
 	options := []*DialogOption{{
 		Id:   DialogCloseActionId,
-		Name: "Cancel",
+		Name: localization.LocalizationCommonCancel,
 	}}
 	if includeConfirm {
 		options = slices.Insert(options, 0, &DialogOption{
-			Id:   confirmActionId,
-			Name: confirmLabel,
+			Id:       confirmActionId,
+			Name:     confirmLabel,
+			Severity: severity,
 		})
 	}
 	return options

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -104,6 +104,17 @@ func NewFileBrowser(application *tview.Application) *FileBrowserComponent {
 	})
 	tableContainer.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		key := event.Key()
+
+		if event.Modifiers()&tcell.ModAlt != 0 {
+			switch {
+			case key == tcell.KeyUp:
+				fileBrowser.goUp()
+				return nil
+			default:
+				return nil
+			}
+		}
+
 		if fileBrowser.GetSelection() != nil {
 			switch {
 			case key == tcell.KeyRight:
@@ -112,7 +123,7 @@ func NewFileBrowser(application *tview.Application) *FileBrowserComponent {
 			case key == tcell.KeyEnter:
 				fileBrowser.openActionDialog(fileBrowser.GetSelection())
 				return nil
-			case event.Rune() == 'd':
+			case key == tcell.KeyDelete:
 				currentSelection := fileBrowser.GetSelection()
 				if currentSelection != nil && currentSelection.HasReal() {
 					fileBrowser.openDeleteDialog(currentSelection)

--- a/internal/ui/localization/localizations.go
+++ b/internal/ui/localization/localizations.go
@@ -1,0 +1,9 @@
+package localization
+
+const (
+	LocalizationSelectActionDialogTitle = " 📋 Select Action "
+
+	LocalizationCommonClose  = "Close"
+	LocalizationCommonCancel = "Cancel"
+	LocalizationCommonDelete = "Delete"
+)

--- a/internal/ui/table/table_component.go
+++ b/internal/ui/table/table_component.go
@@ -176,6 +176,7 @@ func (c *RowSelectionTable[T]) createLayout() {
 					c.addToMultiSelection(c.GetSelectedEntry())
 					return nil
 				default:
+					return nil
 				}
 			}
 


### PR DESCRIPTION
## Summary

This PR improves keyboard navigation and interaction consistency across the TUI.

### Changes

- Add `Alt + Up` keyboard shortcut for navigating up in the file browser
  - Improves keyboard-driven navigation efficiency
  - Provides a more ergonomic alternative to existing navigation controls

- Prevent actions from triggering when modifier keys are active
  - Reduces accidental command execution
  - Improves overall input handling consistency

- Change delete action key binding from `d` to the `Delete` key
  - Avoids accidental deletions during normal navigation
  - Aligns destructive actions with more conventional key mappings

- Refactor dialog option handling to use localized labels
  - Improves internationalization support
  - Centralizes dialog label management

- Add severity levels to dialog options
  - Enables clearer visual distinction between informational, warning, and destructive actions
  - Improves dialog UX and readability

## Motivation

This update improves usability and safety for keyboard-focused workflows by refining shortcut behavior, reducing accidental actions, and making dialogs more expressive and localization-friendly.

## Screenshot

<img width="474" height="308" alt="image" src="https://github.com/user-attachments/assets/6ce33a5e-b43d-47bf-bfee-0bf9115cb0a6" />
