### PR TITLE
Bugfix/#110 selection when navigating to the parent

### DIFF
--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	path2 "path"
 	"slices"
-	"strings"
 	"time"
 	"zfs-file-history/internal/configuration"
 	"zfs-file-history/internal/data"
@@ -353,8 +352,11 @@ func (fileBrowser *FileBrowserComponent) goUp() {
 
 func (fileBrowser *FileBrowserComponent) SetPathWithSelection(newPath string, newSelection string) {
 	fileBrowser.SetPath(newPath, false)
+
+	// select the directory entry of the path we were coming from
+	parentEntryName := path2.Base(path2.Clean(newSelection))
 	for _, entry := range fileBrowser.GetEntries() {
-		if strings.Contains(entry.GetRealPath(), newSelection) {
+		if entry.Name == parentEntryName {
 			fileBrowser.selectFileEntry(entry)
 			return
 		}
@@ -475,11 +477,12 @@ func (fileBrowser *FileBrowserComponent) updateTableContents() {
 	fileBrowser.tableContainer.SetTitle(title)
 	newEntries := fileBrowser.computeTableEntries()
 	fileBrowser.tableContainer.SetData(newEntries)
-	fileBrowser.restoreSelectionForPath()
 }
 
 func (fileBrowser *FileBrowserComponent) selectFileEntry(newSelection *data.FileBrowserEntry) {
-	fileBrowser.emit(SelectedTableEntryChangedEvent{newSelection})
+	defer func() {
+		fileBrowser.emit(SelectedTableEntryChangedEvent{newSelection})
+	}()
 	if fileBrowser.GetSelection() == newSelection {
 		return
 	}
@@ -504,7 +507,7 @@ func (fileBrowser *FileBrowserComponent) restoreSelectionForPath() bool {
 		} else {
 			var index int
 			if rememberedSelectionInfo.Entry == nil {
-				fileBrowser.selectHeader()
+				fileBrowser.SelectHeader()
 				return true
 			} else {
 				index = slices.IndexFunc(entries, func(entry *data.FileBrowserEntry) bool {
@@ -580,7 +583,7 @@ func (fileBrowser *FileBrowserComponent) enterFileEntry(selection *data.FileBrow
 		fileBrowser.SetPath(selection.GetRealPath(), true)
 	}
 	if !fileBrowser.restoreSelectionForPath() {
-		fileBrowser.selectFirstEntryIfExists()
+		fileBrowser.SelectFirstEntryIfExists()
 	}
 }
 
@@ -657,11 +660,11 @@ func (fileBrowser *FileBrowserComponent) GetLayout() *tview.Pages {
 	return fileBrowser.layout
 }
 
-func (fileBrowser *FileBrowserComponent) selectHeader() {
+func (fileBrowser *FileBrowserComponent) SelectHeader() {
 	fileBrowser.tableContainer.SelectHeader()
 }
 
-func (fileBrowser *FileBrowserComponent) selectFirstEntryIfExists() {
+func (fileBrowser *FileBrowserComponent) SelectFirstEntryIfExists() {
 	fileBrowser.tableContainer.SelectFirstIfExists()
 }
 

--- a/internal/ui/main_page.go
+++ b/internal/ui/main_page.go
@@ -151,6 +151,7 @@ func (mainPage *MainPage) ToggleFocus() {
 	} else if mainPage.datasetInfo.HasFocus() {
 		nextFocusedComponent = mainPage.snapshotBrowser
 	} else {
+		nextFocusedComponent = mainPage.fileBrowser
 		logging.Warning("Unexpected focus state")
 	}
 

--- a/internal/ui/main_page.go
+++ b/internal/ui/main_page.go
@@ -140,6 +140,7 @@ func (mainPage *MainPage) Init(path string) {
 	mainPage.datasetInfo.SetPath(path)
 	mainPage.snapshotBrowser.SetPath(path, false)
 	mainPage.fileBrowser.SetPath(path, false)
+	mainPage.fileBrowser.SelectFirstEntryIfExists()
 }
 
 func (mainPage *MainPage) ToggleFocus() {

--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -305,7 +305,9 @@ func (snapshotBrowser *SnapshotBrowserComponent) restoreSelectionForDataset() {
 }
 
 func (snapshotBrowser *SnapshotBrowserComponent) selectSnapshot(snapshot *data.SnapshotBrowserEntry) {
-	snapshotBrowser.emit(SelectedSnapshotChanged{snapshot})
+	defer func() {
+		snapshotBrowser.emit(SelectedSnapshotChanged{snapshot})
+	}()
 	if snapshotBrowser.GetSelection() == snapshot || snapshotBrowser.GetSelection() != nil && snapshot != nil && snapshotBrowser.GetSelection().Snapshot.Path == snapshot.Snapshot.Path {
 		return
 	}


### PR DESCRIPTION
Fixes #110

This pull request refactors and improves the file browser and related UI components, focusing on selection handling, code clarity, and consistency. The main changes include making selection methods public, improving how selections are restored and emitted, and ensuring the file browser has a consistent initial selection.

Launch in subdirectory:

<img width="1044" height="465" alt="image" src="https://github.com/user-attachments/assets/c1949eaa-4c39-415e-a5a1-28721dafebc0" />

Press "Left Arrow":

<img width="1054" height="334" alt="image" src="https://github.com/user-attachments/assets/46de649c-5423-47e2-bc9e-c0b2435ce3e3" />


**Selection handling and UI consistency:**
* Changed `selectHeader` and `selectFirstEntryIfExists` methods in `FileBrowserComponent` to be public (`SelectHeader`, `SelectFirstEntryIfExists`) for better accessibility and consistent naming. Updated all internal calls to use the new method names. [[1]](diffhunk://#diff-a6621c5d3741b9e292c23e5a43fe15aa6197e1e082c062dac955dfa91d524e69L507-R510) [[2]](diffhunk://#diff-a6621c5d3741b9e292c23e5a43fe15aa6197e1e082c062dac955dfa91d524e69L583-R586) [[3]](diffhunk://#diff-a6621c5d3741b9e292c23e5a43fe15aa6197e1e082c062dac955dfa91d524e69L660-R667)
* Ensured the file browser always selects the first entry on initialization by calling `SelectFirstEntryIfExists` in `MainPage.Init`.
* Improved focus toggling in `MainPage` to default to the file browser if no other component has focus, increasing UI robustness.

**Selection restoration and event emission:**
* Refactored selection restoration logic in `FileBrowserComponent.SetPathWithSelection` to select the directory entry by name rather than by substring match, making selection restoration more accurate.
* Updated selection methods in both file and snapshot browsers to emit selection change events via a `defer` statement, ensuring events are always emitted after selection changes. [[1]](diffhunk://#diff-a6621c5d3741b9e292c23e5a43fe15aa6197e1e082c062dac955dfa91d524e69L478-R485) [[2]](diffhunk://#diff-3f7b65205a51e651e654903522151c92091ba1cfbe6d39d37b2bf2d5428c7590R308-R310)

**Code cleanup:**
* Removed an unused `strings` import from `file_browser.go`.