### PR TITLE
Feature/dataset info improvements

### DIFF
--- a/internal/ui/dataset_info/dataset_info.go
+++ b/internal/ui/dataset_info/dataset_info.go
@@ -126,7 +126,7 @@ func (datasetInfo *DatasetInfoComponent) updateUi() {
 		// Format key with trailing colon, maintaining clean alignment padding
 		labelText := fmt.Sprintf("%s:", entry.Name)
 
-		out.WriteString(fmt.Sprintf("%s%-*s[-] %s%s[-]\n",
+		out.WriteString(fmt.Sprintf("%s%*s[-] %s%s[-]\n",
 			keyColorTag,
 			maxKeyLen+1, // +1 maps to the colon addition
 			tview.Escape(labelText),

--- a/internal/ui/dataset_info/dataset_info.go
+++ b/internal/ui/dataset_info/dataset_info.go
@@ -86,7 +86,7 @@ func (datasetInfo *DatasetInfoComponent) updateUi() {
 	properties := []*DatasetInfoTableEntry{
 		{Name: "Type", Value: dataset.GetType()},
 		{Name: "Name", Value: dataset.GetName()},
-		{Name: "Creation", Value: dataset.GetCreationString()}, // e.g., "Mon May 25 14:23 2025"
+		{Name: "Creation", Value: dataset.GetCreationString().Format(theme.Style.Format.DateTime)},
 		{Name: "Mountpoint", Value: dataset.GetMountPoint()},
 		{Name: "Mounted", Value: dataset.GetMounted()},
 		{Name: "Readonly", Value: dataset.GetReadonly()}, // "on" or "off"

--- a/internal/ui/dataset_info/dataset_info.go
+++ b/internal/ui/dataset_info/dataset_info.go
@@ -86,12 +86,23 @@ func (datasetInfo *DatasetInfoComponent) updateUi() {
 	properties := []*DatasetInfoTableEntry{
 		{Name: "Type", Value: dataset.GetType()},
 		{Name: "Name", Value: dataset.GetName()},
+		{Name: "Creation", Value: dataset.GetCreationString()}, // e.g., "Mon May 25 14:23 2025"
 		{Name: "Mountpoint", Value: dataset.GetMountPoint()},
 		{Name: "Mounted", Value: dataset.GetMounted()},
+		{Name: "Readonly", Value: dataset.GetReadonly()}, // "on" or "off"
 		{Name: "Volsize", Value: humanize.IBytes(dataset.GetVolSize())},
 		{Name: "Avail", Value: humanize.IBytes(dataset.GetAvailable())},
 		{Name: "Used", Value: humanize.IBytes(dataset.GetUsed())},
-		{Name: "Compression", Value: dataset.GetCompression()},
+		{Name: "Compression", Value: fmt.Sprintf("%s (%s)", dataset.GetCompression(), dataset.GetCompressRatio())}, // Combine for compact view
+		{Name: "Snapdir", Value: dataset.GetSnapdir()},                                                             // "visible" or "hidden"
+		{Name: "Case", Value: dataset.GetCaseSensitivity()},                                                        // "sensitive" / "insensitive"
+	}
+
+	// If encryption is utilized on the host pool
+	if dataset.IsEncrypted() {
+		properties = append(properties, &DatasetInfoTableEntry{
+			Name: "Encryption", Value: fmt.Sprintf("%s [%s]", dataset.GetEncryption(), dataset.GetKeyStatus()),
+		})
 	}
 
 	if !util.IsBlank(dataset.GetOrigin()) {
@@ -173,22 +184,32 @@ func resolveValueColor(name, value string) tcell.Color {
 		return tcell.ColorGray
 	}
 
+	lowerName := strings.ToLower(name)
+	lowerValue := strings.ToLower(value)
+
+	// Warning / Restrictive States
+	if lowerName == "readonly" && lowerValue == "on" {
+		return tcell.ColorOrange // Visual cue that writes/restores are blocked
+	}
+	if strings.Contains(lowerValue, "unavailable") {
+		return tcell.ColorRed // Key is missing/locked
+	}
+
 	// Paths / Mountpoints
-	if strings.HasPrefix(value, "/") || strings.EqualFold(name, "mountpoint") || strings.EqualFold(name, "origin") {
+	if strings.HasPrefix(value, "/") || lowerName == "mountpoint" || lowerName == "origin" {
 		return tcell.ColorLightBlue
 	}
 
-	// Booleans (yes/no)
-	if strings.EqualFold(value, "yes") || strings.EqualFold(value, "true") {
+	// Booleans / Positive Flags
+	if lowerValue == "yes" || lowerValue == "true" || lowerValue == "on" || lowerValue == "visible" {
 		return tcell.ColorGreen
 	}
-	if strings.EqualFold(value, "no") || strings.EqualFold(value, "false") {
+	if lowerValue == "no" || lowerValue == "false" || lowerValue == "off" || lowerValue == "hidden" {
 		return tcell.ColorRed
 	}
 
-	// File Sizes (Volsize, Avail, Used)
-	lowerName := strings.ToLower(name)
-	if lowerName == "volsize" || lowerName == "avail" || lowerName == "used" {
+	// File Sizes & Ratios
+	if lowerName == "volsize" || lowerName == "avail" || lowerName == "used" || strings.Contains(lowerValue, "x") {
 		return tcell.ColorYellow
 	}
 

--- a/internal/ui/dataset_info/dataset_info.go
+++ b/internal/ui/dataset_info/dataset_info.go
@@ -2,6 +2,7 @@ package dataset_info
 
 import (
 	"fmt"
+	"strings"
 	"zfs-file-history/internal/logging"
 	"zfs-file-history/internal/ui/shortcut_helper"
 	"zfs-file-history/internal/ui/theme"
@@ -17,7 +18,7 @@ import (
 type DatasetInfoComponent struct {
 	application *tview.Application
 	dataset     *zfs.Dataset
-	layout      *tview.Table
+	layout      *tview.TextView
 }
 
 func NewDatasetInfo(application *tview.Application) *DatasetInfoComponent {
@@ -58,7 +59,10 @@ type DatasetInfoTableEntry struct {
 }
 
 func (datasetInfo *DatasetInfoComponent) createLayout() {
-	layout := tview.NewTable()
+	layout := tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(false).
+		SetScrollable(true)
 	layout.SetBorder(true)
 	uiutil.SetupWindow(layout, "Dataset")
 
@@ -103,28 +107,35 @@ func (datasetInfo *DatasetInfoComponent) updateUi() {
 	}
 
 	datasetInfo.layout.Clear()
-	columns, rows := 2, len(properties)
-	for row := 0; row < rows; row++ {
-		entry := properties[row]
 
-		for col := 0; col < columns; col++ {
-			var text string
-			var cellAlignment int
-			var cellColor = tcell.ColorWhite
-			if col == 0 {
-				text = fmt.Sprintf("%s:", entry.Name)
-				cellAlignment = tview.AlignRight
-				cellColor = theme.Colors.Layout.Table.Header
-			} else {
-				text = entry.Value
-				cellAlignment = tview.AlignLeft
-			}
-			datasetInfo.layout.SetCell(
-				row, col,
-				tview.NewTableCell(text).SetAlign(cellAlignment).SetTextColor(cellColor),
-			)
+	// Calculate alignment padding dynamically based on longest key name
+	maxKeyLen := 0
+	for _, entry := range properties {
+		if len(entry.Name) > maxKeyLen {
+			maxKeyLen = len(entry.Name)
 		}
 	}
+
+	keyColorTag := colorTag(theme.Colors.Layout.Table.Header)
+	var out strings.Builder
+
+	for _, entry := range properties {
+		valueColor := resolveValueColor(entry.Name, entry.Value)
+		valueColorTag := colorTag(valueColor)
+
+		// Format key with trailing colon, maintaining clean alignment padding
+		labelText := fmt.Sprintf("%s:", entry.Name)
+
+		out.WriteString(fmt.Sprintf("%s%-*s[-] %s%s[-]\n",
+			keyColorTag,
+			maxKeyLen+1, // +1 maps to the colon addition
+			tview.Escape(labelText),
+			valueColorTag,
+			tview.Escape(entry.Value),
+		))
+	}
+
+	datasetInfo.layout.SetText(out.String())
 }
 
 func (datasetInfo *DatasetInfoComponent) HasFocus() bool {
@@ -148,4 +159,39 @@ func (datasetInfo *DatasetInfoComponent) CreateSnapshot(name string) error {
 
 func (datasetInfo *DatasetInfoComponent) GetShortcutMap() []shortcut_helper.ShortcutEntry {
 	return []shortcut_helper.ShortcutEntry{}
+}
+
+// Helper formatting utilities matching ConfigInfo Component patterns
+
+func colorTag(color tcell.Color) string {
+	r, g, b := color.RGB()
+	return fmt.Sprintf("[#%02x%02x%02x]", uint8(r), uint8(g), uint8(b))
+}
+
+func resolveValueColor(name, value string) tcell.Color {
+	if value == "" || value == "-" || strings.EqualFold(value, "none") {
+		return tcell.ColorGray
+	}
+
+	// Paths / Mountpoints
+	if strings.HasPrefix(value, "/") || strings.EqualFold(name, "mountpoint") || strings.EqualFold(name, "origin") {
+		return tcell.ColorLightBlue
+	}
+
+	// Booleans (yes/no)
+	if strings.EqualFold(value, "yes") || strings.EqualFold(value, "true") {
+		return tcell.ColorGreen
+	}
+	if strings.EqualFold(value, "no") || strings.EqualFold(value, "false") {
+		return tcell.ColorRed
+	}
+
+	// File Sizes (Volsize, Avail, Used)
+	lowerName := strings.ToLower(name)
+	if lowerName == "volsize" || lowerName == "avail" || lowerName == "used" {
+		return tcell.ColorYellow
+	}
+
+	// Fallback Default String Color
+	return tcell.ColorWhite
 }

--- a/internal/ui/file_browser/table_container.go
+++ b/internal/ui/file_browser/table_container.go
@@ -27,8 +27,8 @@ func createFileBrowserTable(application *tview.Application) *table.RowSelectionT
 }
 
 func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry *data.FileBrowserEntry) (cells []*tview.TableCell) {
-	status := determineStatusIndicator(entry)
-	statusColor := determineStatusColor(entry)
+	statusCellText := determineStatusIndicator(entry)
+	statusCellColor := determineStatusColor(entry)
 	typeCellText := determineTypeCellText(entry)
 	typeCellColor := determineTypeCellColor(entry)
 
@@ -44,14 +44,14 @@ func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry 
 			if entry.GetStat().IsDir() {
 				cellText = fmt.Sprintf("/%s", cellText)
 			}
-			cellColor = statusColor
+			cellColor = statusCellColor
 		case columnType:
 			cellText = typeCellText
 			cellColor = typeCellColor
 			cellAlignment = tview.AlignCenter
 		case columnDiff:
-			cellText = status
-			cellColor = statusColor
+			cellText = statusCellText
+			cellColor = statusCellColor
 			cellAlignment = tview.AlignCenter
 		case columnPermissions:
 			cellText = determinePermissionsText(entry)
@@ -66,10 +66,10 @@ func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry 
 			cellText = entry.GetStat().ModTime().Format(theme.Style.Format.DateTime)
 			switch entry.DiffState {
 			case diff_state.Added, diff_state.Deleted:
-				cellColor = statusColor
+				cellColor = statusCellColor
 			case diff_state.Modified:
 				if entry.RealFile.Stat.ModTime() != entry.SnapshotFiles[0].Stat.ModTime() {
-					cellColor = statusColor
+					cellColor = statusCellColor
 				} else {
 					cellColor = tcell.ColorWhite
 				}
@@ -87,10 +87,10 @@ func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry 
 			}
 			switch entry.DiffState {
 			case diff_state.Added, diff_state.Deleted:
-				cellColor = statusColor
+				cellColor = statusCellColor
 			case diff_state.Modified:
 				if entry.RealFile.Stat.Size() != entry.SnapshotFiles[0].Stat.Size() {
-					cellColor = statusColor
+					cellColor = statusCellColor
 				} else {
 					cellColor = tcell.ColorWhite
 				}
@@ -107,11 +107,11 @@ func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry 
 			SetAlign(cellAlignment).
 			SetExpansion(cellExpansion)
 
-		// Keep row status visible while selected by using statusColor as selected background.
+		// Keep row statusCellText visible while selected by using statusCellColor as selected background.
 		cell.SetSelectedStyle(
 			tcell.StyleDefault.
 				Foreground(theme.Colors.Layout.Table.SelectedForeground).
-				Background(statusColor),
+				Background(statusCellColor),
 		)
 		cells = append(cells, cell)
 	}

--- a/internal/ui/snapshot_browser/table_container.go
+++ b/internal/ui/snapshot_browser/table_container.go
@@ -26,10 +26,11 @@ func createSnapshotBrowserTable(application *tview.Application) *table.RowSelect
 
 func createSnapshotBrowserTableCells(row int, columns []*table.Column, entry *data.SnapshotBrowserEntry) (cells []*tview.TableCell) {
 	result := []*tview.TableCell{}
+	statusColor := determineStatusColor(entry)
 	for _, column := range columns {
 		cellText := "N/A"
 		cellAlign := tview.AlignLeft
-		cellColor := tcell.ColorWhite
+		cellColor := determineBaseTextColor(entry)
 		switch column {
 		case columnDate:
 			cellText = entry.Snapshot.Properties.CreationDate.Format(theme.Style.Format.DateTime)
@@ -65,10 +66,47 @@ func createSnapshotBrowserTableCells(row int, columns []*table.Column, entry *da
 			cellText = fmt.Sprintf("%d", entry.Snapshot.Properties.Clones)
 		}
 		cell := tview.NewTableCell(cellText).
-			SetTextColor(cellColor).SetAlign(cellAlign)
+			SetTextColor(cellColor).
+			SetAlign(cellAlign)
+
+		cell.SetSelectedStyle(
+			tcell.StyleDefault.
+				Foreground(theme.Colors.Layout.Table.SelectedForeground).
+				Background(statusColor),
+		)
 		result = append(result, cell)
 	}
 	return result
+}
+
+func determineStatusColor(entry *data.SnapshotBrowserEntry) tcell.Color {
+	switch entry.DiffState {
+	case diff_state.Equal:
+		return theme.Colors.SnapshotBrowser.Table.State.Equal
+	case diff_state.Deleted:
+		return theme.Colors.SnapshotBrowser.Table.State.SnapshotOnly
+	case diff_state.Added:
+		return theme.Colors.SnapshotBrowser.Table.State.LocalOnly
+	case diff_state.Modified:
+		return theme.Colors.SnapshotBrowser.Table.State.Modified
+	case diff_state.Unknown:
+		fallthrough
+	default:
+		return theme.Colors.SnapshotBrowser.Table.State.Unknown
+	}
+}
+
+func determineBaseTextColor(entry *data.SnapshotBrowserEntry) tcell.Color {
+	switch entry.DiffState {
+	case diff_state.Deleted:
+		fallthrough
+	case diff_state.Added:
+		fallthrough
+	case diff_state.Modified:
+		return tcell.ColorWhite
+	default:
+		return tcell.ColorGray
+	}
 }
 
 func createSnapshotBrowserTableSortFunction(entries []*data.SnapshotBrowserEntry, columnToSortBy *table.Column, inverted bool) []*data.SnapshotBrowserEntry {

--- a/internal/zfs/dataset.go
+++ b/internal/zfs/dataset.go
@@ -119,6 +119,16 @@ func (dataset *Dataset) GetName() string {
 	return dataset.Path
 }
 
+func (dataset *Dataset) GetCreationString() string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropCreation)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	return ""
+}
+
 func (dataset *Dataset) GetType() string {
 	if dataset.rawGolibzfsData != nil {
 		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropType)
@@ -206,6 +216,16 @@ func (dataset *Dataset) GetCompression() string {
 	return ""
 }
 
+func (dataset *Dataset) GetCompressRatio() string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropCompressratio)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	return ""
+}
+
 func (dataset *Dataset) GetOrigin() string {
 	if dataset.rawGolibzfsData != nil {
 		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropOrigin)
@@ -273,6 +293,119 @@ func (dataset *Dataset) GetMounted() string {
 	}
 	if dataset.rawGozfsData != nil {
 		val, err := dataset.rawGozfsData.GetProperty("mounted")
+		if err == nil {
+			return val
+		}
+	}
+	return ""
+}
+
+// on or off
+func (dataset *Dataset) GetReadonly() string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropReadonly)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		val, err := dataset.rawGozfsData.GetProperty("readonly")
+		if err == nil {
+			return val
+		}
+	}
+	return ""
+}
+
+func (dataset *Dataset) GetSnapdir() string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropSnapdir)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		val, err := dataset.rawGozfsData.GetProperty("snapdir")
+		if err == nil {
+			return val
+		}
+	}
+	return ""
+}
+
+func (dataset *Dataset) GetCaseSensitivity() string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropCase)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		val, err := dataset.rawGozfsData.GetProperty("case")
+		if err == nil {
+			return val
+		}
+	}
+	return ""
+}
+
+func (dataset *Dataset) GetQuota() string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropQuota)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		val, err := dataset.rawGozfsData.GetProperty("quota")
+		if err == nil {
+			return val
+		}
+	}
+	return ""
+}
+
+func (dataset *Dataset) IsEncrypted() bool {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropEncryption)
+		if err == nil {
+			return prop.Value != "off"
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		val, err := dataset.rawGozfsData.GetProperty("encryption")
+		if err == nil {
+			return val != "off"
+		}
+	}
+	return false
+}
+
+func (dataset *Dataset) GetEncryption() string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropEncryption)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		val, err := dataset.rawGozfsData.GetProperty("encryption")
+		if err == nil {
+			return val
+		}
+	}
+	return ""
+}
+
+func (dataset *Dataset) GetKeyStatus() string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropKeyStatus)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		val, err := dataset.rawGozfsData.GetProperty("key_status")
 		if err == nil {
 			return val
 		}

--- a/internal/zfs/dataset.go
+++ b/internal/zfs/dataset.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	path2 "path"
 	"strconv"
+	"time"
 	"zfs-file-history/internal/logging"
 	"zfs-file-history/internal/util"
 
@@ -119,14 +120,21 @@ func (dataset *Dataset) GetName() string {
 	return dataset.Path
 }
 
-func (dataset *Dataset) GetCreationString() string {
+func (dataset *Dataset) GetCreationString() time.Time {
 	if dataset.rawGolibzfsData != nil {
 		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropCreation)
 		if err == nil {
-			return prop.Value
+			rawValue := prop.Value
+			valueInt, err := strconv.ParseInt(rawValue, 10, 64)
+			if err != nil {
+				logging.Error("Could not parse creation time for dataset %s: %s", dataset.Path, err.Error())
+				return time.Time{}
+			}
+			// convert integer to *time.Time
+			return time.Unix(valueInt, 0)
 		}
 	}
-	return ""
+	return time.Time{}
 }
 
 func (dataset *Dataset) GetType() string {

--- a/internal/zfs/dataset.go
+++ b/internal/zfs/dataset.go
@@ -77,6 +77,60 @@ func FindHostDataset(path string) (*Dataset, error) {
 	}
 }
 
+func (dataset *Dataset) getPropertyString(libProp golibzfs.Prop, goProp string) string {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(libProp)
+		if err == nil {
+			return prop.Value
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		val, err := dataset.rawGozfsData.GetProperty(goProp)
+		if err == nil {
+			return val
+		}
+	}
+	return ""
+}
+
+func (dataset *Dataset) getPropertyInt(libProp golibzfs.Prop, goProp string, defaultValue int) int {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(libProp)
+		if err == nil {
+			val, err := strconv.Atoi(prop.Value)
+			if err == nil {
+				return val
+			}
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		prop, err := dataset.rawGozfsData.GetProperty(goProp)
+		if err == nil {
+			val, err := strconv.Atoi(prop)
+			if err == nil {
+				return val
+			}
+		}
+	}
+	return defaultValue
+}
+
+func (dataset *Dataset) getPropertyUint64(libProp golibzfs.Prop, goValue uint64) uint64 {
+	if dataset.rawGolibzfsData != nil {
+		prop, err := dataset.rawGolibzfsData.GetProperty(libProp)
+		if err == nil {
+			number, err := strconv.ParseUint(prop.Value, 10, 64)
+			if err == nil {
+				return number
+			}
+		}
+	}
+	if dataset.rawGozfsData != nil {
+		return goValue
+	}
+	return 0
+}
+
 func (dataset *Dataset) GetSnapshotsDir() string {
 	return path2.Join(dataset.HiddenZfsPath, "snapshot")
 }
@@ -138,287 +192,89 @@ func (dataset *Dataset) GetCreationString() time.Time {
 }
 
 func (dataset *Dataset) GetType() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropType)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		return dataset.rawGozfsData.Type
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropType, "type")
 }
 
 func (dataset *Dataset) GetMountPoint() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropMountpoint)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		return dataset.rawGozfsData.Mountpoint
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropMountpoint, "mountpoint")
 }
 
 func (dataset *Dataset) GetVolSize() uint64 {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropVolsize)
-		if err == nil {
-			number, err := strconv.ParseUint(prop.Value, 10, 64)
-			if err == nil {
-				return number
-			}
-		}
-	}
+	var goValue uint64
 	if dataset.rawGozfsData != nil {
-		return dataset.rawGozfsData.Volsize
+		goValue = dataset.rawGozfsData.Volsize
 	}
-	return 0
+	return dataset.getPropertyUint64(golibzfs.DatasetPropVolsize, goValue)
 }
 
 func (dataset *Dataset) GetAvailable() uint64 {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropAvailable)
-		if err == nil {
-			number, err := strconv.ParseUint(prop.Value, 10, 64)
-			if err == nil {
-				return number
-			}
-		}
-	}
+	var goValue uint64
 	if dataset.rawGozfsData != nil {
-		return dataset.rawGozfsData.Avail
+		goValue = dataset.rawGozfsData.Avail
 	}
-	return 0
+	return dataset.getPropertyUint64(golibzfs.DatasetPropAvailable, goValue)
 }
 
 func (dataset *Dataset) GetUsed() uint64 {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropUsed)
-		if err == nil {
-			number, err := strconv.ParseUint(prop.Value, 10, 64)
-			if err == nil {
-				return number
-			}
-		}
-	}
+	var goValue uint64
 	if dataset.rawGozfsData != nil {
-		return dataset.rawGozfsData.Used
+		goValue = dataset.rawGozfsData.Used
 	}
-	return 0
+	return dataset.getPropertyUint64(golibzfs.DatasetPropUsed, goValue)
 }
 
 func (dataset *Dataset) GetCompression() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropCompression)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		return dataset.rawGozfsData.Compression
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropCompression, "compression")
 }
 
 func (dataset *Dataset) GetCompressRatio() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropCompressratio)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropCompressratio, "compressratio")
 }
 
 func (dataset *Dataset) GetOrigin() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropOrigin)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		return dataset.rawGozfsData.Origin
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropOrigin, "origin")
 }
 
 func (dataset *Dataset) GetSnapshotCount() int {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropSnapshotCount)
-		if err == nil {
-			val, err := strconv.Atoi(prop.Value)
-			if err == nil {
-				return val
-			}
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		prop, err := dataset.rawGozfsData.GetProperty("snapshot_count")
-		if err == nil {
-			val, err := strconv.Atoi(prop)
-			if err == nil {
-				return val
-			}
-		}
-	}
-	return 0
+	return dataset.getPropertyInt(golibzfs.DatasetPropSnapshotCount, "snapshot_count", 0)
 }
 
 // GetSnapshotLimit returns the maximum number of snapshots that can be created
 func (dataset *Dataset) GetSnapshotLimit() int {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropSnapshotLimit)
-		if err == nil {
-			val, err := strconv.Atoi(prop.Value)
-			if err == nil {
-				return val
-			}
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		prop, err := dataset.rawGozfsData.GetProperty("snapshot_limit")
-		if err == nil {
-			val, err := strconv.Atoi(prop)
-			if err == nil {
-				return val
-			}
-		}
-	}
-	return -1
+	return dataset.getPropertyInt(golibzfs.DatasetPropSnapshotLimit, "snapshot_limit", -1)
 }
 
 func (dataset *Dataset) GetMounted() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropMounted)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		val, err := dataset.rawGozfsData.GetProperty("mounted")
-		if err == nil {
-			return val
-		}
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropMounted, "mounted")
 }
 
 // on or off
 func (dataset *Dataset) GetReadonly() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropReadonly)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		val, err := dataset.rawGozfsData.GetProperty("readonly")
-		if err == nil {
-			return val
-		}
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropReadonly, "readonly")
 }
 
 func (dataset *Dataset) GetSnapdir() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropSnapdir)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		val, err := dataset.rawGozfsData.GetProperty("snapdir")
-		if err == nil {
-			return val
-		}
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropSnapdir, "snapdir")
 }
 
 func (dataset *Dataset) GetCaseSensitivity() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropCase)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		val, err := dataset.rawGozfsData.GetProperty("case")
-		if err == nil {
-			return val
-		}
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropCase, "case")
 }
 
 func (dataset *Dataset) GetQuota() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropQuota)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		val, err := dataset.rawGozfsData.GetProperty("quota")
-		if err == nil {
-			return val
-		}
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropQuota, "quota")
 }
 
 func (dataset *Dataset) IsEncrypted() bool {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropEncryption)
-		if err == nil {
-			return prop.Value != "off"
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		val, err := dataset.rawGozfsData.GetProperty("encryption")
-		if err == nil {
-			return val != "off"
-		}
-	}
-	return false
+	return dataset.getPropertyString(golibzfs.DatasetPropEncryption, "encryption") != "off"
 }
 
 func (dataset *Dataset) GetEncryption() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropEncryption)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		val, err := dataset.rawGozfsData.GetProperty("encryption")
-		if err == nil {
-			return val
-		}
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropEncryption, "encryption")
 }
 
 func (dataset *Dataset) GetKeyStatus() string {
-	if dataset.rawGolibzfsData != nil {
-		prop, err := dataset.rawGolibzfsData.GetProperty(golibzfs.DatasetPropKeyStatus)
-		if err == nil {
-			return prop.Value
-		}
-	}
-	if dataset.rawGozfsData != nil {
-		val, err := dataset.rawGozfsData.GetProperty("key_status")
-		if err == nil {
-			return val
-		}
-	}
-	return ""
+	return dataset.getPropertyString(golibzfs.DatasetPropKeyStatus, "key_status")
 }
 
 func (dataset *Dataset) CreateSnapshot(name string) error {


### PR DESCRIPTION
This pull request significantly refactors and enhances the dataset info UI and related dataset property accessors. The main improvements are a more compact, color-coded, and readable display for dataset properties, and a major simplification and unification of property retrieval logic in the `Dataset` model. There are also improvements to color handling for file and snapshot browser tables to ensure consistent status highlighting.

<img width="473" height="800" alt="image" src="https://github.com/user-attachments/assets/9a1bfcbd-cfc8-4b30-934f-5a0853f9e69f" />

Key changes:

**UI Enhancements for Dataset Info:**
- The dataset info panel is now rendered using a `tview.TextView` instead of a table, allowing for colorized, aligned, and more compact output. Property keys and values are color-coded for readability, and special states (like "readonly" or missing keys) are visually highlighted. Helper functions for color formatting and value-based color resolution have been added to support this. [[1]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124L20-R21) [[2]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124L61-R65) [[3]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124L106-R149) [[4]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124R174-R218)
- Several new dataset properties are now displayed, such as creation time, readonly status, snapdir, case sensitivity, and encryption details. Compression info now includes the compression ratio for a more concise view.

**Dataset Property Accessor Refactor:**
- All dataset property getters in `internal/zfs/dataset.go` have been refactored to use new helper methods (`getPropertyString`, `getPropertyInt`, `getPropertyUint64`). This unifies property retrieval between the two ZFS backends and reduces code duplication.
- New accessors have been added for properties such as creation time, readonly, snapdir, case sensitivity, quota, encryption, and key status. The encryption accessor also exposes whether encryption is enabled.
- The creation time is now returned as a `time.Time` object for proper formatting in the UI.

**File and Snapshot Browser Table Improvements:**
- Status color variables in the file and snapshot browser tables have been renamed for clarity, and status colors are now consistently used for both text and selected row backgrounds, improving the visual feedback for users. [[1]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L30-R31) [[2]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L47-R54) [[3]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L69-R72) [[4]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L90-R93) [[5]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L110-R114) [[6]](diffhunk://#diff-bd56682f24723b5d48dc02e8bf2b537d15b0b8a804009ecb0b29890a7f516bd9R29-R33) [[7]](diffhunk://#diff-bd56682f24723b5d48dc02e8bf2b537d15b0b8a804009ecb0b29890a7f516bd9L68-R111)
- A new function for determining the base text color of snapshot browser entries has been added for better differentiation of modified/added/deleted states.

**General Improvements:**
- Imports have been updated to include required packages for new features. [[1]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124R5) [[2]](diffhunk://#diff-ff9ab041a51fc2f42697ed78a87202f0d237f0eea3292d7e2a497b86fce4c605R9)

These changes collectively modernize the dataset info UI, improve maintainability, and enhance the user experience with clearer and more informative displays.

- UI enhancements and color-coding in dataset info (`dataset_info.go`): [[1]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124L20-R21) [[2]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124L61-R65) [[3]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124L106-R149) [[4]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124R174-R218)
- Expanded dataset property display and formatting (`dataset_info.go`):
- Unified and extended dataset property accessors (`dataset.go`): [[1]](diffhunk://#diff-ff9ab041a51fc2f42697ed78a87202f0d237f0eea3292d7e2a497b86fce4c605R80-R133) [[2]](diffhunk://#diff-ff9ab041a51fc2f42697ed78a87202f0d237f0eea3292d7e2a497b86fce4c605L122-R277)
- Consistent status color handling in file/snapshot browser tables: [[1]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L30-R31) [[2]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L47-R54) [[3]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L69-R72) [[4]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L90-R93) [[5]](diffhunk://#diff-ed99c0335817bb2e6d5e70a81a10ae55f118b5fcaaa45c63dd93647112513931L110-R114) [[6]](diffhunk://#diff-bd56682f24723b5d48dc02e8bf2b537d15b0b8a804009ecb0b29890a7f516bd9R29-R33) [[7]](diffhunk://#diff-bd56682f24723b5d48dc02e8bf2b537d15b0b8a804009ecb0b29890a7f516bd9L68-R111)
- Import updates for new utilities: [[1]](diffhunk://#diff-901660c1478f5e1c1e8d57d18a125db282dff33e246fe4ab63af7ade38b9c124R5) [[2]](diffhunk://#diff-ff9ab041a51fc2f42697ed78a87202f0d237f0eea3292d7e2a497b86fce4c605R9)