### PR TITLE
Bugfix/snapshot diff

### DIFF
--- a/internal/data/file_browser_entry.go
+++ b/internal/data/file_browser_entry.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"zfs-file-history/internal/data/diff_state"
+	"zfs-file-history/internal/util"
 	"zfs-file-history/internal/zfs"
 )
 
@@ -33,16 +34,11 @@ func (file *SnapshotFile) Equal(e SnapshotFile) bool {
 }
 
 func (file *SnapshotFile) HasChanged() bool {
-	return file.Snapshot.CheckIfFileHasChanged(file.Path)
+	return file.Snapshot.IsRealFileDifferent(file.Path)
 }
 
 func (file *SnapshotFile) Exists() bool {
-	statSnap, err := os.Lstat(file.Path)
-	if os.IsNotExist(err) {
-		return false
-	} else {
-		return statSnap != nil
-	}
+	return util.FileExists(file.Path)
 }
 
 type FileBrowserEntryType int

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -8,6 +8,15 @@ import (
 	"syscall"
 )
 
+func FileExists(path string) bool {
+	statSnap, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	return statSnap != nil
+}
+
 func ListFilesIn(path string) (result []string, err error) {
 	if _, err = os.Lstat(path); err != nil {
 		if os.IsNotExist(err) {

--- a/internal/zfs/snapshot.go
+++ b/internal/zfs/snapshot.go
@@ -254,7 +254,7 @@ func (s *Snapshot) RestoreFile(srcPath string) error {
 	return err
 }
 
-func (s *Snapshot) CheckIfFileHasChanged(path string) bool {
+func (s *Snapshot) IsRealFileDifferent(path string) bool {
 	realPath := path
 	snapshotPath := s.GetSnapshotPath(path)
 
@@ -295,6 +295,7 @@ func (s *Snapshot) ContainsFile(entry string) (bool, error) {
 	return true, nil
 }
 
+// DetermineDiffState Determine the diff state between a real file and its snapshot counterpart
 func (s *Snapshot) DetermineDiffState(path string) diff_state.DiffState {
 	containsFile, err := s.ContainsFile(path)
 	if err != nil {
@@ -302,7 +303,7 @@ func (s *Snapshot) DetermineDiffState(path string) diff_state.DiffState {
 		return diff_state.Unknown
 	}
 	if containsFile {
-		if s.CheckIfFileHasChanged(path) {
+		if s.IsRealFileDifferent(path) {
 			return diff_state.Modified
 		} else {
 			return diff_state.Equal

--- a/internal/zfs/snapshot.go
+++ b/internal/zfs/snapshot.go
@@ -297,20 +297,24 @@ func (s *Snapshot) ContainsFile(entry string) (bool, error) {
 
 // DetermineDiffState Determine the diff state between a real file and its snapshot counterpart
 func (s *Snapshot) DetermineDiffState(path string) diff_state.DiffState {
-	containsFile, err := s.ContainsFile(path)
+	snapshotContainsFile, err := s.ContainsFile(path)
 	if err != nil {
 		logging.Error("Could not determine if snapshot contains file %s: %s", path, err.Error())
 		return diff_state.Unknown
 	}
-	if containsFile {
+	realFileExists := util.FileExists(path)
+	if snapshotContainsFile && realFileExists {
 		if s.IsRealFileDifferent(path) {
 			return diff_state.Modified
-		} else {
-			return diff_state.Equal
 		}
-	} else {
+		return diff_state.Equal
+	} else if snapshotContainsFile {
+		return diff_state.Deleted
+	} else if realFileExists {
 		return diff_state.Added
 	}
+
+	return diff_state.Equal
 }
 
 func (s *Snapshot) Destroy(recursive bool, dependantClones bool) error {

--- a/internal/zfs/snapshot_test.go
+++ b/internal/zfs/snapshot_test.go
@@ -1,0 +1,126 @@
+package zfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+	"zfs-file-history/internal/data/diff_state"
+)
+
+func TestDetermineDiffState(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Setup mock dataset and snapshot structure
+	datasetPath := filepath.Join(tempDir, "dataset")
+	err := os.MkdirAll(datasetPath, 0755)
+	if err != nil {
+		t.Fatalf("failed to create dataset path: %v", err)
+	}
+
+	snapDirBase := filepath.Join(datasetPath, ".zfs", "snapshot")
+	snapName := "snap1"
+	snapPath := filepath.Join(snapDirBase, snapName)
+	err = os.MkdirAll(snapPath, 0755)
+	if err != nil {
+		t.Fatalf("failed to create snapshot path: %v", err)
+	}
+
+	dataset := &Dataset{
+		Path:          datasetPath,
+		HiddenZfsPath: filepath.Join(datasetPath, ".zfs"),
+	}
+
+	snapshot := &Snapshot{
+		Name:          snapName,
+		Path:          snapPath,
+		ParentDataset: dataset,
+	}
+
+	t.Run("Added", func(t *testing.T) {
+		// File exists in real but NOT in snapshot
+		filePath := filepath.Join(datasetPath, "newfile.txt")
+		err := os.WriteFile(filePath, []byte("content"), 0644)
+		if err != nil {
+			t.Fatalf("failed to create file: %v", err)
+		}
+		defer os.Remove(filePath)
+
+		state := snapshot.DetermineDiffState(filePath)
+		if state != diff_state.Added {
+			t.Errorf("expected Added, got %v", state)
+		}
+	})
+
+	t.Run("Equal", func(t *testing.T) {
+		// File exists in both and is identical
+		fileName := "equal.txt"
+		realFilePath := filepath.Join(datasetPath, fileName)
+		snapFilePath := filepath.Join(snapPath, fileName)
+
+		content := []byte("identical content")
+		now := time.Now().Truncate(time.Second) // filesystem might truncate
+
+		err := os.WriteFile(realFilePath, content, 0644)
+		if err != nil {
+			t.Fatalf("failed to create real file: %v", err)
+		}
+		defer os.Remove(realFilePath)
+
+		err = os.WriteFile(snapFilePath, content, 0644)
+		if err != nil {
+			t.Fatalf("failed to create snap file: %v", err)
+		}
+		defer os.Remove(snapFilePath)
+
+		// Ensure same mod time
+		err = os.Chtimes(realFilePath, now, now)
+		if err != nil {
+			t.Fatalf("failed to set times: %v", err)
+		}
+		err = os.Chtimes(snapFilePath, now, now)
+		if err != nil {
+			t.Fatalf("failed to set times: %v", err)
+		}
+
+		state := snapshot.DetermineDiffState(realFilePath)
+		if state != diff_state.Equal {
+			t.Errorf("expected Equal, got %v", state)
+		}
+	})
+
+	t.Run("Modified", func(t *testing.T) {
+		// File exists in both but is different
+		fileName := "modified.txt"
+		realFilePath := filepath.Join(datasetPath, fileName)
+		snapFilePath := filepath.Join(snapPath, fileName)
+
+		err := os.WriteFile(realFilePath, []byte("new content"), 0644)
+		if err != nil {
+			t.Fatalf("failed to create real file: %v", err)
+		}
+		defer os.Remove(realFilePath)
+
+		err = os.WriteFile(snapFilePath, []byte("old content"), 0644)
+		if err != nil {
+			t.Fatalf("failed to create snap file: %v", err)
+		}
+		defer os.Remove(snapFilePath)
+
+		// Set different mod times to ensure IsRealFileDifferent returns true
+		now := time.Now().Truncate(time.Second)
+		err = os.Chtimes(realFilePath, now, now)
+		if err != nil {
+			t.Fatalf("failed to set real times: %v", err)
+		}
+		err = os.Chtimes(snapFilePath, now.Add(-time.Hour), now.Add(-time.Hour))
+		if err != nil {
+			t.Fatalf("failed to set snap times: %v", err)
+		}
+
+		state := snapshot.DetermineDiffState(realFilePath)
+		if state != diff_state.Modified {
+			t.Errorf("expected Modified, got %v", state)
+		}
+	})
+}

--- a/internal/zfs/snapshot_test.go
+++ b/internal/zfs/snapshot_test.go
@@ -8,119 +8,116 @@ import (
 	"zfs-file-history/internal/data/diff_state"
 )
 
+type fileState struct {
+	exists  bool
+	content string
+	modTime time.Time
+}
+
 func TestDetermineDiffState(t *testing.T) {
+	// 1. Setup baseline shared structs
 	tempDir := t.TempDir()
-
-	// Setup mock dataset and snapshot structure
 	datasetPath := filepath.Join(tempDir, "dataset")
-	err := os.MkdirAll(datasetPath, 0755)
-	if err != nil {
-		t.Fatalf("failed to create dataset path: %v", err)
-	}
-
 	snapDirBase := filepath.Join(datasetPath, ".zfs", "snapshot")
-	snapName := "snap1"
-	snapPath := filepath.Join(snapDirBase, snapName)
-	err = os.MkdirAll(snapPath, 0755)
-	if err != nil {
-		t.Fatalf("failed to create snapshot path: %v", err)
-	}
+	snapPath := filepath.Join(snapDirBase, "snap1")
 
 	dataset := &Dataset{
 		Path:          datasetPath,
 		HiddenZfsPath: filepath.Join(datasetPath, ".zfs"),
 	}
-
 	snapshot := &Snapshot{
-		Name:          snapName,
+		Name:          "snap1",
 		Path:          snapPath,
 		ParentDataset: dataset,
 	}
 
-	t.Run("Added", func(t *testing.T) {
-		// File exists in real but NOT in snapshot
-		filePath := filepath.Join(datasetPath, "newfile.txt")
-		err := os.WriteFile(filePath, []byte("content"), 0644)
-		if err != nil {
-			t.Fatalf("failed to create file: %v", err)
-		}
-		defer os.Remove(filePath)
+	now := time.Now().Truncate(time.Second)
 
-		state := snapshot.DetermineDiffState(filePath)
-		if state != diff_state.Added {
-			t.Errorf("expected Added, got %v", state)
-		}
-	})
+	// 2. The Table: Declare all scenarios cleanly as data
+	tests := []struct {
+		name      string
+		filename  string
+		realState fileState
+		snapState fileState
+		wantState diff_state.DiffState
+	}{
+		{
+			name:      "Added",
+			filename:  "added.txt",
+			realState: fileState{exists: true, content: "content"},
+			snapState: fileState{exists: false},
+			wantState: diff_state.Added,
+		},
+		{
+			name:      "Equal",
+			filename:  "equal.txt",
+			realState: fileState{exists: true, content: "identical content", modTime: now},
+			snapState: fileState{exists: true, content: "identical content", modTime: now},
+			wantState: diff_state.Equal,
+		},
+		{
+			name:      "Modified",
+			filename:  "modified.txt",
+			realState: fileState{exists: true, content: "new content", modTime: now},
+			snapState: fileState{exists: true, content: "old content", modTime: now.Add(-time.Hour)},
+			wantState: diff_state.Modified,
+		},
+		{
+			name:      "Deleted",
+			filename:  "deleted.txt",
+			realState: fileState{exists: false},
+			snapState: fileState{exists: true, content: "was here"},
+			wantState: diff_state.Deleted,
+		},
+		{
+			name:      "NeitherExists",
+			filename:  "nonexistent.txt",
+			realState: fileState{exists: false},
+			snapState: fileState{exists: false},
+			wantState: diff_state.Equal,
+		},
+	}
 
-	t.Run("Equal", func(t *testing.T) {
-		// File exists in both and is identical
-		fileName := "equal.txt"
-		realFilePath := filepath.Join(datasetPath, fileName)
-		snapFilePath := filepath.Join(snapPath, fileName)
+	// 3. Execution Loop
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			realFilePath := filepath.Join(datasetPath, tt.filename)
+			snapFilePath := filepath.Join(snapPath, tt.filename)
 
-		content := []byte("identical content")
-		now := time.Now().Truncate(time.Second) // filesystem might truncate
+			// Automatically handle filesystem setups based on table configurations
+			setupFile(t, realFilePath, tt.realState)
+			setupFile(t, snapFilePath, tt.snapState)
 
-		err := os.WriteFile(realFilePath, content, 0644)
-		if err != nil {
-			t.Fatalf("failed to create real file: %v", err)
-		}
-		defer os.Remove(realFilePath)
+			// Run assertion
+			gotState := snapshot.DetermineDiffState(realFilePath)
+			if gotState != tt.wantState {
+				t.Errorf("DetermineDiffState() = %v, want %v", gotState, tt.wantState)
+			}
+		})
+	}
+}
 
-		err = os.WriteFile(snapFilePath, content, 0644)
-		if err != nil {
-			t.Fatalf("failed to create snap file: %v", err)
-		}
-		defer os.Remove(snapFilePath)
+// Helper function to keep execution loop completely readable
+func setupFile(t *testing.T, path string, state fileState) {
+	t.Helper() // Flags this function as a test helper for clearer stack traces
+	if !state.exists {
+		return
+	}
 
-		// Ensure same mod time
-		err = os.Chtimes(realFilePath, now, now)
-		if err != nil {
-			t.Fatalf("failed to set times: %v", err)
-		}
-		err = os.Chtimes(snapFilePath, now, now)
-		if err != nil {
-			t.Fatalf("failed to set times: %v", err)
-		}
+	// Ensure directories exist
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create dir for %s: %v", path, err)
+	}
 
-		state := snapshot.DetermineDiffState(realFilePath)
-		if state != diff_state.Equal {
-			t.Errorf("expected Equal, got %v", state)
-		}
-	})
+	// Write content
+	if err := os.WriteFile(path, []byte(state.content), 0644); err != nil {
+		t.Fatalf("failed to write file %s: %v", path, err)
+	}
 
-	t.Run("Modified", func(t *testing.T) {
-		// File exists in both but is different
-		fileName := "modified.txt"
-		realFilePath := filepath.Join(datasetPath, fileName)
-		snapFilePath := filepath.Join(snapPath, fileName)
-
-		err := os.WriteFile(realFilePath, []byte("new content"), 0644)
-		if err != nil {
-			t.Fatalf("failed to create real file: %v", err)
+	// Adjust times if explicitly requested
+	if !state.modTime.IsZero() {
+		if err := os.Chtimes(path, state.modTime, state.modTime); err != nil {
+			t.Fatalf("failed to set times on %s: %v", path, err)
 		}
-		defer os.Remove(realFilePath)
-
-		err = os.WriteFile(snapFilePath, []byte("old content"), 0644)
-		if err != nil {
-			t.Fatalf("failed to create snap file: %v", err)
-		}
-		defer os.Remove(snapFilePath)
-
-		// Set different mod times to ensure IsRealFileDifferent returns true
-		now := time.Now().Truncate(time.Second)
-		err = os.Chtimes(realFilePath, now, now)
-		if err != nil {
-			t.Fatalf("failed to set real times: %v", err)
-		}
-		err = os.Chtimes(snapFilePath, now.Add(-time.Hour), now.Add(-time.Hour))
-		if err != nil {
-			t.Fatalf("failed to set snap times: %v", err)
-		}
-
-		state := snapshot.DetermineDiffState(realFilePath)
-		if state != diff_state.Modified {
-			t.Errorf("expected Modified, got %v", state)
-		}
-	})
+	}
 }


### PR DESCRIPTION
This pull request refactors and improves file existence and diff state logic in the ZFS snapshot codebase, making the code more modular and testable. It introduces a new utility function for file existence checks, renames key methods for clarity, and adds comprehensive unit tests for diff state determination.

**Refactoring and logic improvements:**

* Replaced direct file existence checks in `SnapshotFile.Exists()` with a new utility function `util.FileExists`, and updated all usages to call this new function for consistency and testability. (`internal/data/file_browser_entry.go`, `internal/util/file.go`) [[1]](diffhunk://#diff-5767e900eafcd0acd01411c36773cd8767e3adfd8c32d691f0f124ccf51cc8d0L36-R41) [[2]](diffhunk://#diff-44d2eb4fb913c420a076b93c862cc01cc58f6323a75c88422987d6430db19b2fR11-R19)
* Renamed `CheckIfFileHasChanged` to `IsRealFileDifferent` in the `Snapshot` struct, clarifying its purpose, and updated all references accordingly. (`internal/zfs/snapshot.go`, `internal/data/file_browser_entry.go`) [[1]](diffhunk://#diff-388408f9e26fe6ea2beec7c3e5bacd2a68fa984ce111e7bd827838eed31c6d3bL257-R257) [[2]](diffhunk://#diff-5767e900eafcd0acd01411c36773cd8767e3adfd8c32d691f0f124ccf51cc8d0L36-R41)
* Refactored `DetermineDiffState` to use the new file existence checks and to handle all combinations of real and snapshot file presence, improving correctness and maintainability. (`internal/zfs/snapshot.go`)

**Testing:**

* Added a comprehensive table-driven unit test for `DetermineDiffState`, covering all key scenarios: added, equal, modified, deleted, and neither file exists. (`internal/zfs/snapshot_test.go`)

**Utility function:**

* Introduced `util.FileExists(path string) bool` for consistent and reusable file existence checks throughout the codebase. (`internal/util/file.go`)