### PR TITLE
Feature/improve responsiveness when selecting file browser entries

### DIFF
--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -313,18 +313,21 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 	snapshotBrowser.tableContainer.SetData(initialEntries)
 	snapshotBrowser.updateTableTitle()
 
-	// Step 2: Compute actual diffs in background goroutine
+	// Get the sorted entries from the table container (determines screen top-to-bottom layout)
+	sortedEntries := snapshotBrowser.tableContainer.GetEntries()
+
+	// Step 2: Compute actual diffs in background goroutine, processing them in sorted order
 	go func() {
 		filePath := ""
 		if fileEntry != nil {
 			filePath = fileEntry.GetRealPath()
 		}
 
-		// Keep a local working copy of entries
-		localEntries := make([]*data.SnapshotBrowserEntry, len(snapshots))
-		for i, snap := range snapshots {
+		// Keep a local working copy in the exact sorted order
+		localEntries := make([]*data.SnapshotBrowserEntry, len(sortedEntries))
+		for i, entry := range sortedEntries {
 			localEntries[i] = &data.SnapshotBrowserEntry{
-				Snapshot:  snap,
+				Snapshot:  entry.Snapshot,
 				DiffState: diff_state.Unknown,
 			}
 		}

--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 	"zfs-file-history/internal/data"
 	"zfs-file-history/internal/data/diff_state"
@@ -40,6 +41,9 @@ type SnapshotBrowserComponent struct {
 	selectedSnapshotMemory *uiutil.SelectionMemory[data.SnapshotBrowserEntry]
 
 	isRestoringSelection bool
+
+	diffCancel context.CancelFunc
+	diffSeq    atomic.Uint64
 }
 
 type snapshotLoadResult struct {
@@ -270,9 +274,104 @@ func (snapshotBrowser *SnapshotBrowserComponent) updateCurrentSnapshotEntries(qu
 }
 
 func (snapshotBrowser *SnapshotBrowserComponent) updateTableEntries() {
-	newEntries := snapshotBrowser.computeTableEntries(snapshotBrowser.currentSnapshots)
-	snapshotBrowser.tableContainer.SetData(newEntries)
+	snapshotBrowser.startAsyncDiffCalculation()
+}
+
+func (snapshotBrowser *SnapshotBrowserComponent) cancelDiffCalculation() {
+	if snapshotBrowser.diffCancel != nil {
+		snapshotBrowser.diffCancel()
+		snapshotBrowser.diffCancel = nil
+	}
+}
+
+func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
+	snapshotBrowser.cancelDiffCalculation()
+
+	snapshots := snapshotBrowser.currentSnapshots
+	fileEntry := snapshotBrowser.currentFileEntry
+
+	// If no snapshots, clear the table instantly
+	if len(snapshots) == 0 {
+		snapshotBrowser.tableContainer.SetData([]*data.SnapshotBrowserEntry{})
+		snapshotBrowser.updateTableTitle()
+		return
+	}
+
+	// Create cancellable context and increment sequence
+	ctx, cancel := context.WithCancel(context.Background())
+	snapshotBrowser.diffCancel = cancel
+	seq := snapshotBrowser.diffSeq.Add(1)
+
+	// Step 1: Instantly render table with Unknown ("N/A") states
+	initialEntries := make([]*data.SnapshotBrowserEntry, len(snapshots))
+	for i, snap := range snapshots {
+		initialEntries[i] = &data.SnapshotBrowserEntry{
+			Snapshot:  snap,
+			DiffState: diff_state.Unknown,
+		}
+	}
+	snapshotBrowser.tableContainer.SetData(initialEntries)
 	snapshotBrowser.updateTableTitle()
+
+	// Step 2: Compute actual diffs in background goroutine
+	go func() {
+		filePath := ""
+		if fileEntry != nil {
+			filePath = fileEntry.GetRealPath()
+		}
+
+		// Keep a local working copy of entries
+		localEntries := make([]*data.SnapshotBrowserEntry, len(snapshots))
+		for i, snap := range snapshots {
+			localEntries[i] = &data.SnapshotBrowserEntry{
+				Snapshot:  snap,
+				DiffState: diff_state.Unknown,
+			}
+		}
+
+		// Closure to safely push local updates to UI thread
+		updateUI := func() {
+			entriesCopy := make([]*data.SnapshotBrowserEntry, len(localEntries))
+			for i, entry := range localEntries {
+				entriesCopy[i] = &data.SnapshotBrowserEntry{
+					Snapshot:  entry.Snapshot,
+					DiffState: entry.DiffState,
+				}
+			}
+
+			snapshotBrowser.application.QueueUpdateDraw(func() {
+				// Discard update if a newer selection calculation has started
+				if seq != snapshotBrowser.diffSeq.Load() {
+					return
+				}
+				snapshotBrowser.tableContainer.SetData(entriesCopy)
+				snapshotBrowser.updateTableTitle()
+			})
+		}
+
+		for i, entry := range localEntries {
+			// Abort immediately if user changed selection and cancelled context
+			if ctx.Err() != nil {
+				return
+			}
+
+			if filePath != "" {
+				entry.DiffState = entry.Snapshot.DetermineDiffState(filePath)
+			}
+
+			// Incremental Redraw Logic:
+			// - First 5 entries: Redraw after each (gives instant feedback on visible entries)
+			// - Remaining entries: Batch update every 10 entries (optimizes UI rendering)
+			// - Final entry: Always push the final update
+			isFirstFew := i < 5
+			isBatchEnd := (i+1)%10 == 0
+			isLast := i == len(localEntries)-1
+
+			if isFirstFew || isBatchEnd || isLast {
+				updateUI()
+			}
+		}
+	}()
 }
 
 func (snapshotBrowser *SnapshotBrowserComponent) Focus() {
@@ -281,28 +380,6 @@ func (snapshotBrowser *SnapshotBrowserComponent) Focus() {
 
 func (snapshotBrowser *SnapshotBrowserComponent) HasFocus() bool {
 	return snapshotBrowser.container.HasFocus()
-}
-
-func (snapshotBrowser *SnapshotBrowserComponent) computeTableEntries(snapshots []*zfs.Snapshot) []*data.SnapshotBrowserEntry {
-	result := []*data.SnapshotBrowserEntry{}
-
-	if snapshotBrowser.hostDataset == nil {
-		return result
-	}
-
-	for _, snapshot := range snapshots {
-		diffState := diff_state.Unknown
-		if snapshotBrowser.currentFileEntry != nil {
-			filePath := snapshotBrowser.currentFileEntry.GetRealPath()
-			diffState = snapshot.DetermineDiffState(filePath)
-		}
-		result = append(result, &data.SnapshotBrowserEntry{
-			Snapshot:  snapshot,
-			DiffState: diffState,
-		})
-	}
-
-	return result
 }
 
 func (snapshotBrowser *SnapshotBrowserComponent) updateTableTitle() {


### PR DESCRIPTION
# Asynchronous & Incremental Diff Loading in Snapshot Browser

## Description

This pull request resolves the blocking interface lag/freeze that occurs when navigating or changing the selected entry in the file browser. 

Previously, selecting a file triggered synchronous filesystem attribute queries (`os.Lstat`) for every snapshot in the dataset on the main UI thread. In datasets with many snapshots, this caused a significant, blocking delay (input lag) while scrolling.

This PR moves the diff state calculation to a background goroutine, updates the UI incrementally to ensure high responsiveness, and adds proper request cancellation and ordering logic.

---

## Key Changes

### 1. Asynchronous Diff Computation
* Modified `SnapshotBrowserComponent` to compute diff states in a background goroutine rather than synchronously blocking the main UI thread during `updateTableEntries`.
* When a new file is selected, the snapshots table is instantly rendered with `Unknown` (`N/A`) diff states, giving the user immediate, non-blocking feedback.

### 2. Presentation Order Synchronization (Top-to-Bottom)
* Before starting the background calculation, we retrieve the sorted entries in their exact presentation order from the table container (`tableContainer.GetEntries()`).
* The background calculation iterates from index `0` to `len - 1` of this sorted list, causing the calculated diff states to populate smoothly from top to bottom on the screen (regardless of active sorting parameters, e.g. ascending or descending).

### 3. Concurrency Safety & Cancellation
* Introduced `diffCancel context.CancelFunc` and `diffSeq atomic.Uint64` fields to the component.
* If the user selects a new file or directory before the current calculation finishes, the active background context is canceled immediately to stop filesystem queries, and any stale UI update requests from the previous sequence are discarded.

### 4. Incremental UI Redraws
* To prevent rendering bottlenecks from calling `SetData()` too frequently, the background task updates the table:
  * Immediately after calculating each of the first `5` entries (providing near-instant feedback for the visible rows).
  * In batches of `10` entries for the remainder of the calculation.
  * Once more at the very end to push final changes.

---

## Files Modified
* [internal/ui/snapshot_browser/snapshot_browser.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/snapshot_browser/snapshot_browser.go)

## Verification
* Unit tests successfully verified (`go test ./...`).
* Build compilation verified (`just build`).
* Manually tested scrolling and sorting: navigation is responsive and smooth.
