### PR TITLE
Asynchronous & Flicker-Free Diff Loading with Loading Column

### DIFF
--- a/internal/data/file_browser_entry.go
+++ b/internal/data/file_browser_entry.go
@@ -55,6 +55,7 @@ type FileBrowserEntry struct {
 	SnapshotFiles []*SnapshotFile
 	Type          FileBrowserEntryType
 	DiffState     diff_state.DiffState
+	IsLoading     bool
 }
 
 func (entry FileBrowserEntry) TableRowId() string {

--- a/internal/data/file_browser_entry.go
+++ b/internal/data/file_browser_entry.go
@@ -78,17 +78,20 @@ func NewFileBrowserEntry(name string, latestFile *RealFile, snapshots []*Snapsho
 func (entry *FileBrowserEntry) GetRealPath() string {
 	if entry.HasReal() {
 		return entry.RealFile.Path
-	} else {
+	} else if len(entry.SnapshotFiles) > 0 && entry.SnapshotFiles[0] != nil {
 		return entry.SnapshotFiles[0].OriginalPath
 	}
+	return ""
 }
 
 func (entry *FileBrowserEntry) GetStat() os.FileInfo {
 	if entry.HasReal() {
 		return entry.RealFile.Stat
 	}
-
-	return entry.SnapshotFiles[0].Stat
+	if len(entry.SnapshotFiles) > 0 && entry.SnapshotFiles[0] != nil {
+		return entry.SnapshotFiles[0].Stat
+	}
+	return nil
 }
 
 // HasSnapshot indicated whether a snapshot file exists on the dataset for this entry.

--- a/internal/data/snapshot_browser_entry.go
+++ b/internal/data/snapshot_browser_entry.go
@@ -8,6 +8,7 @@ import (
 type SnapshotBrowserEntry struct {
 	Snapshot  *zfs.Snapshot
 	DiffState diff_state.DiffState
+	IsLoading bool
 }
 
 func (s SnapshotBrowserEntry) TableRowId() string {

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -67,7 +67,6 @@ var (
 	}
 
 	tableColumns = []*table.Column{
-		table.ColumnLoading,
 		columnPermissions,
 		columnUID,
 		columnGID,
@@ -79,7 +78,6 @@ var (
 	}
 
 	initialActiveTableColumns = []*table.Column{
-		table.ColumnLoading,
 		columnSize,
 		columnDateTime,
 		columnName,
@@ -794,17 +792,14 @@ func (fileBrowser *FileBrowserComponent) showDialog(d dialog.Dialog, actionHandl
 
 func (fileBrowser *FileBrowserComponent) openColumnSelectionDialog() {
 	currentActive := fileBrowser.tableContainer.GetColumnSpec()
-	configurableActive := slices.DeleteFunc(slices.Clone(currentActive), func(c *table.Column) bool {
-		return c.Id == table.ColumnLoading.Id
-	})
 
 	d := dialog.NewColumnSelectionDialog(
 		fileBrowser.application,
 		"Configure File Browser Columns",
 		tableColumns,
-		configurableActive,
+		slices.Clone(currentActive),
 		func(activeColumns []*table.Column) {
-			fileBrowser.tableContainer.SetActiveColumns(append([]*table.Column{table.ColumnLoading}, activeColumns...))
+			fileBrowser.tableContainer.SetActiveColumns(activeColumns)
 		},
 	)
 	fileBrowser.showDialog(d, func(action dialog.DialogActionId) bool {

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -537,14 +537,16 @@ func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
 			state diff_state.DiffState
 		}
 		var batch []diffResult
+		lastDrawTime := time.Now()
 
-		pushBatch := func() {
+		pushBatch := func(forceDraw bool) {
 			if len(batch) == 0 {
 				return
 			}
 			batchCopy := batch
 			batch = nil
-			fileBrowser.application.QueueUpdateDraw(func() {
+
+			updateFunc := func() {
 				if !fileBrowser.diffLoader.IsCurrentSequence(seq) {
 					return
 				}
@@ -553,7 +555,13 @@ func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
 					res.entry.IsLoading = false
 					fileBrowser.tableContainer.UpdateEntry(res.entry)
 				}
-			})
+			}
+
+			if forceDraw {
+				fileBrowser.application.QueueUpdateDraw(updateFunc)
+			} else {
+				fileBrowser.application.QueueUpdate(updateFunc)
+			}
 		}
 
 		for i, entry := range entriesToProcess {
@@ -565,9 +573,14 @@ func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
 
 			batch = append(batch, diffResult{entry: entry, state: diffState})
 
-			// Push batch for first few items, then every 10 items, or at the end
-			if i < 5 || len(batch) >= 10 || i == len(entriesToProcess)-1 {
-				pushBatch()
+			now := time.Now()
+			isLast := i == len(entriesToProcess)-1
+			// Draw at most once every 50ms to prevent SSH connection flooding
+			if isLast || now.Sub(lastDrawTime) > 50*time.Millisecond {
+				pushBatch(true)
+				lastDrawTime = now
+			} else if len(batch) >= 10 {
+				pushBatch(false)
 			}
 		}
 	}()
@@ -587,9 +600,6 @@ func (fileBrowser *FileBrowserComponent) Refresh() {
 
 	title := fmt.Sprintf("Path: %s", fileBrowser.truncatePath(fileBrowser.path, maxWidth))
 	fileBrowser.tableContainer.SetTitle(title)
-
-	// Synchronously clear the table so the UI correctly reflects that we are loading a new directory
-	fileBrowser.tableContainer.SetData([]*data.FileBrowserEntry{})
 
 	ctx, seq := fileBrowser.refreshLoader.Start()
 

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -432,7 +432,7 @@ func (fileBrowser *FileBrowserComponent) SetPath(newPath string, checkExists boo
 		}
 
 		fileBrowser.emit(PathChangedEvent{NewPath: newPath})
-		fileBrowser.Refresh()
+		fileBrowser.Refresh(false)
 	}
 }
 
@@ -512,7 +512,7 @@ func (fileBrowser *FileBrowserComponent) SetSelectedSnapshot(snapshot *data.Snap
 	}
 
 	fileBrowser.currentSnapshot = snapshot
-	fileBrowser.Refresh()
+	fileBrowser.Refresh(true)
 }
 
 func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
@@ -606,7 +606,7 @@ func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
 	}()
 }
 
-func (fileBrowser *FileBrowserComponent) Refresh() {
+func (fileBrowser *FileBrowserComponent) Refresh(debounce bool) {
 	fileBrowser.showMessage(status_message.NewInfoStatusMessage("Refreshing..."))
 
 	_, _, width, _ := fileBrowser.tableContainer.GetLayout().GetRect()
@@ -625,10 +625,12 @@ func (fileBrowser *FileBrowserComponent) Refresh() {
 
 	go func() {
 		// Debounce rapid calls to Refresh (e.g. from fast scrolling in SnapshotBrowser)
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(50 * time.Millisecond):
+		if debounce {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
 		}
 
 		entries, err := fileBrowser.computeTableEntries(ctx)
@@ -773,7 +775,7 @@ func (fileBrowser *FileBrowserComponent) updateFileWatcher() {
 	}
 	fileBrowser.fileWatcher = util.NewFileWatcher(path)
 	action := func(s string) {
-		fileBrowser.Refresh()
+		fileBrowser.Refresh(false)
 		fileBrowser.application.Draw()
 	}
 	err := fileBrowser.fileWatcher.Watch(action)
@@ -826,7 +828,7 @@ func (fileBrowser *FileBrowserComponent) runRestoreFileAction(entry *data.FileBr
 	fileBrowser.showDialog(d, func(action dialog.DialogActionId) bool {
 		switch action {
 		case dialog.DialogCloseActionId:
-			fileBrowser.Refresh()
+			fileBrowser.Refresh(false)
 		}
 		return false
 	})
@@ -864,7 +866,7 @@ func (fileBrowser *FileBrowserComponent) showDiff(selection *data.FileBrowserEnt
 	fileBrowser.showDialog(d, func(action dialog.DialogActionId) bool {
 		switch action {
 		case dialog.DialogCloseActionId:
-			fileBrowser.Refresh()
+			fileBrowser.Refresh(false)
 		}
 		return false
 	})

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -394,16 +394,12 @@ func (fileBrowser *FileBrowserComponent) goUp() {
 }
 
 func (fileBrowser *FileBrowserComponent) SetPathWithSelection(newPath string, newSelection string) {
-	fileBrowser.SetPath(newPath, false)
-
-	// select the directory entry of the path we were coming from
+	// Remember the intended selection for the new path before triggering async refresh
 	parentEntryName := path2.Base(path2.Clean(newSelection))
-	for _, entry := range fileBrowser.GetEntries() {
-		if entry.Name == parentEntryName {
-			fileBrowser.selectFileEntry(entry)
-			return
-		}
-	}
+	fakeEntry := &data.FileBrowserEntry{Name: parentEntryName}
+	fileBrowser.selectionMemory.Remember(newPath, 0, fakeEntry)
+
+	fileBrowser.SetPath(newPath, false)
 }
 
 func (fileBrowser *FileBrowserComponent) SetPath(newPath string, checkExists bool) {
@@ -536,21 +532,43 @@ func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
 	go func() {
 		defer fileBrowser.diffLoader.Stop(seq)
 
-		for _, entry := range entriesToProcess {
+		type diffResult struct {
+			entry *data.FileBrowserEntry
+			state diff_state.DiffState
+		}
+		var batch []diffResult
+
+		pushBatch := func() {
+			if len(batch) == 0 {
+				return
+			}
+			batchCopy := batch
+			batch = nil
+			fileBrowser.application.QueueUpdateDraw(func() {
+				if !fileBrowser.diffLoader.IsCurrentSequence(seq) {
+					return
+				}
+				for _, res := range batchCopy {
+					res.entry.DiffState = res.state
+					res.entry.IsLoading = false
+					fileBrowser.tableContainer.UpdateEntry(res.entry)
+				}
+			})
+		}
+
+		for i, entry := range entriesToProcess {
 			if ctx.Err() != nil {
 				return
 			}
 
 			diffState := fileBrowser.determineDiffState(entry, snapshotEntry)
 
-			fileBrowser.application.QueueUpdateDraw(func() {
-				if !fileBrowser.diffLoader.IsCurrentSequence(seq) {
-					return
-				}
-				entry.DiffState = diffState
-				entry.IsLoading = false
-				fileBrowser.tableContainer.UpdateEntry(entry)
-			})
+			batch = append(batch, diffResult{entry: entry, state: diffState})
+
+			// Push batch for first few items, then every 10 items, or at the end
+			if i < 5 || len(batch) >= 10 || i == len(entriesToProcess)-1 {
+				pushBatch()
+			}
 		}
 	}()
 }
@@ -569,6 +587,9 @@ func (fileBrowser *FileBrowserComponent) Refresh() {
 
 	title := fmt.Sprintf("Path: %s", fileBrowser.truncatePath(fileBrowser.path, maxWidth))
 	fileBrowser.tableContainer.SetTitle(title)
+
+	// Synchronously clear the table so the UI correctly reflects that we are loading a new directory
+	fileBrowser.tableContainer.SetData([]*data.FileBrowserEntry{})
 
 	ctx, seq := fileBrowser.refreshLoader.Start()
 

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -530,7 +530,7 @@ func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
 		case <-time.After(50 * time.Millisecond):
 		}
 
-		// Pre-emptively set loading state in case computation takes a while
+		// Preemptively set loading state in case computation takes a while
 		fileBrowser.application.QueueUpdate(func() {
 			if !fileBrowser.diffLoader.IsCurrentSequence(seq) {
 				return

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -215,7 +215,7 @@ func (fileBrowser *FileBrowserComponent) Focus() {
 	fileBrowser.application.SetFocus(fileBrowser.layout)
 }
 
-func (fileBrowser *FileBrowserComponent) computeTableEntries(ctx context.Context) ([]*data.FileBrowserEntry, error) {
+func (fileBrowser *FileBrowserComponent) computeTableEntries(ctx context.Context, previousDiffs map[string]diff_state.DiffState) ([]*data.FileBrowserEntry, error) {
 	path := fileBrowser.path
 	snapshotEntry := fileBrowser.currentSnapshot
 
@@ -304,13 +304,6 @@ func (fileBrowser *FileBrowserComponent) computeTableEntries(ctx context.Context
 
 			snapshotFiles := []*data.SnapshotFile{snapshotFile}
 			fileEntries = append(fileEntries, data.NewFileBrowserEntry(snapshotFileName, nil, snapshotFiles, entryType))
-		}
-	}
-
-	previousDiffs := make(map[string]diff_state.DiffState)
-	for _, entry := range fileBrowser.tableContainer.GetEntries() {
-		if entry != nil {
-			previousDiffs[entry.GetRealPath()] = entry.DiffState
 		}
 	}
 
@@ -619,6 +612,13 @@ func (fileBrowser *FileBrowserComponent) Refresh(debounce bool) {
 	title := fmt.Sprintf("Path: %s", fileBrowser.truncatePath(fileBrowser.path, maxWidth))
 	fileBrowser.tableContainer.SetTitle(title)
 
+	previousDiffs := make(map[string]diff_state.DiffState)
+	for _, entry := range fileBrowser.tableContainer.GetEntries() {
+		if entry != nil {
+			previousDiffs[entry.GetRealPath()] = entry.DiffState
+		}
+	}
+
 	ctx, seq := fileBrowser.refreshLoader.Start()
 
 	go func() {
@@ -631,7 +631,7 @@ func (fileBrowser *FileBrowserComponent) Refresh(debounce bool) {
 			}
 		}
 
-		entries, err := fileBrowser.computeTableEntries(ctx)
+		entries, err := fileBrowser.computeTableEntries(ctx, previousDiffs)
 
 		fileBrowser.application.QueueUpdateDraw(func() {
 			if !fileBrowser.refreshLoader.IsCurrentSequence(seq) {

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -532,6 +532,26 @@ func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
 	go func() {
 		defer fileBrowser.diffLoader.Stop(seq)
 
+		// Debounce rapid scrolling
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		// Pre-emptively set loading state in case computation takes a while
+		fileBrowser.application.QueueUpdate(func() {
+			if !fileBrowser.diffLoader.IsCurrentSequence(seq) {
+				return
+			}
+			for _, entry := range entriesToProcess {
+				if entry != nil {
+					entry.IsLoading = true
+					fileBrowser.tableContainer.UpdateEntry(entry)
+				}
+			}
+		})
+
 		type diffResult struct {
 			entry *data.FileBrowserEntry
 			state diff_state.DiffState
@@ -604,6 +624,13 @@ func (fileBrowser *FileBrowserComponent) Refresh() {
 	ctx, seq := fileBrowser.refreshLoader.Start()
 
 	go func() {
+		// Debounce rapid calls to Refresh (e.g. from fast scrolling in SnapshotBrowser)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
+
 		entries, err := fileBrowser.computeTableEntries(ctx)
 
 		fileBrowser.application.QueueUpdateDraw(func() {

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -1,6 +1,7 @@
 package file_browser
 
 import (
+	"context"
 	"fmt"
 	"os"
 	path2 "path"
@@ -66,6 +67,7 @@ var (
 	}
 
 	tableColumns = []*table.Column{
+		table.ColumnLoading,
 		columnPermissions,
 		columnUID,
 		columnGID,
@@ -77,6 +79,7 @@ var (
 	}
 
 	initialActiveTableColumns = []*table.Column{
+		table.ColumnLoading,
 		columnSize,
 		columnDateTime,
 		columnName,
@@ -99,20 +102,31 @@ type FileBrowserComponent struct {
 
 	selectionMemory *uiutil.SelectionMemory[data.FileBrowserEntry]
 	fileWatcher     *util.FileWatcher
+
+	diffLoader    *uiutil.DebouncedLoader
+	refreshLoader *uiutil.DebouncedLoader
 }
 
 func NewFileBrowser(application *tview.Application) *FileBrowserComponent {
-	tableContainer := createFileBrowserTable(application)
-
 	fileBrowser := &FileBrowserComponent{
 		Events: util.NewEmitter[Event](),
 
 		application: application,
 
 		selectionMemory: uiutil.NewSelectionMemory[data.FileBrowserEntry](),
-
-		tableContainer: tableContainer,
 	}
+
+	fileBrowser.diffLoader = uiutil.NewDebouncedLoader(application, func() {
+		for _, entry := range fileBrowser.tableContainer.GetEntries() {
+			if entry != nil && entry.IsLoading {
+				fileBrowser.tableContainer.UpdateEntry(entry)
+			}
+		}
+	})
+
+	fileBrowser.refreshLoader = uiutil.NewDebouncedLoader(application, func() {})
+
+	fileBrowser.tableContainer = fileBrowser.createFileBrowserTable(application)
 
 	fileBrowser.createLayout()
 	fileBrowser.setupTable()
@@ -203,9 +217,13 @@ func (fileBrowser *FileBrowserComponent) Focus() {
 	fileBrowser.application.SetFocus(fileBrowser.layout)
 }
 
-func (fileBrowser *FileBrowserComponent) computeTableEntries() ([]*data.FileBrowserEntry, error) {
+func (fileBrowser *FileBrowserComponent) computeTableEntries(ctx context.Context) ([]*data.FileBrowserEntry, error) {
 	path := fileBrowser.path
 	snapshotEntry := fileBrowser.currentSnapshot
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
 	// list files in current path
 	realFiles, err := util.ListFilesIn(path)
@@ -224,6 +242,9 @@ func (fileBrowser *FileBrowserComponent) computeTableEntries() ([]*data.FileBrow
 
 	// add entries for files which are present on the "real" location (and possibly within a snapshot as well)
 	for _, realFilePath := range realFiles {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		_, realFileName := path2.Split(realFilePath)
 		realFileStat, err := os.Lstat(realFilePath)
 		if err != nil {
@@ -264,6 +285,9 @@ func (fileBrowser *FileBrowserComponent) computeTableEntries() ([]*data.FileBrow
 	if snapshotEntry != nil {
 		// add remaining entries for files which are only present in the snapshot
 		for _, snapshotFilePath := range snapshotFilePaths {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			_, snapshotFileName := path2.Split(snapshotFilePath)
 
 			statSnap, err := os.Lstat(snapshotFilePath)
@@ -285,8 +309,20 @@ func (fileBrowser *FileBrowserComponent) computeTableEntries() ([]*data.FileBrow
 		}
 	}
 
+	previousDiffs := make(map[string]diff_state.DiffState)
+	for _, entry := range fileBrowser.tableContainer.GetEntries() {
+		if entry != nil {
+			previousDiffs[entry.GetRealPath()] = entry.DiffState
+		}
+	}
+
 	for _, entry := range fileEntries {
-		entry.DiffState = fileBrowser.determineDiffState(entry, snapshotEntry)
+		if oldState, exists := previousDiffs[entry.GetRealPath()]; exists {
+			entry.DiffState = oldState
+		} else {
+			entry.DiffState = diff_state.Unknown
+		}
+		entry.IsLoading = true
 	}
 
 	return fileEntries, nil
@@ -483,6 +519,42 @@ func (fileBrowser *FileBrowserComponent) SetSelectedSnapshot(snapshot *data.Snap
 	fileBrowser.Refresh()
 }
 
+func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
+	if fileBrowser.diffLoader != nil {
+		fileBrowser.diffLoader.Cancel()
+	}
+
+	snapshotEntry := fileBrowser.currentSnapshot
+	entriesToProcess := slices.Clone(fileBrowser.tableContainer.GetEntries())
+
+	if len(entriesToProcess) == 0 {
+		return
+	}
+
+	ctx, seq := fileBrowser.diffLoader.Start()
+
+	go func() {
+		defer fileBrowser.diffLoader.Stop(seq)
+
+		for _, entry := range entriesToProcess {
+			if ctx.Err() != nil {
+				return
+			}
+
+			diffState := fileBrowser.determineDiffState(entry, snapshotEntry)
+
+			fileBrowser.application.QueueUpdateDraw(func() {
+				if !fileBrowser.diffLoader.IsCurrentSequence(seq) {
+					return
+				}
+				entry.DiffState = diffState
+				entry.IsLoading = false
+				fileBrowser.tableContainer.UpdateEntry(entry)
+			})
+		}
+	}()
+}
+
 func (fileBrowser *FileBrowserComponent) Refresh() {
 	fileBrowser.showMessage(status_message.NewInfoStatusMessage("Refreshing..."))
 
@@ -490,11 +562,6 @@ func (fileBrowser *FileBrowserComponent) Refresh() {
 	if width == 0 {
 		width = 80
 	}
-	// title is " Path: Path: <path> "
-	// theme.CreateTitleText adds 2 spaces.
-	// Box adds borders (2 chars).
-	// "Path: " is 6 chars.
-	// So available is width - 2 (borders) - 2 (spaces) - 6 (prefix) = width - 10.
 	maxWidth := width - 10
 	if maxWidth < 20 {
 		maxWidth = 20
@@ -503,15 +570,29 @@ func (fileBrowser *FileBrowserComponent) Refresh() {
 	title := fmt.Sprintf("Path: %s", fileBrowser.truncatePath(fileBrowser.path, maxWidth))
 	fileBrowser.tableContainer.SetTitle(title)
 
-	entries, err := fileBrowser.computeTableEntries()
-	if err != nil {
-		fileBrowser.showError(err)
-	} else {
-		fileBrowser.tableContainer.SetData(entries)
-		fileBrowser.restoreSelectionForPath()
-		fileBrowser.updateFileWatcher()
-	}
-	fileBrowser.showMessage(status_message.NewInfoStatusMessage(""))
+	ctx, seq := fileBrowser.refreshLoader.Start()
+
+	go func() {
+		entries, err := fileBrowser.computeTableEntries(ctx)
+
+		fileBrowser.application.QueueUpdateDraw(func() {
+			if !fileBrowser.refreshLoader.IsCurrentSequence(seq) {
+				return
+			}
+			if err != nil {
+				fileBrowser.showError(err)
+			} else {
+				fileBrowser.tableContainer.SetData(entries)
+				fileBrowser.restoreSelectionForPath()
+				fileBrowser.updateFileWatcher()
+
+				fileBrowser.startAsyncDiffCalculation()
+
+				fileBrowser.emit(SelectedTableEntryChangedEvent{fileBrowser.GetSelection()})
+			}
+			fileBrowser.showMessage(status_message.NewInfoStatusMessage(""))
+		})
+	}()
 }
 
 func (fileBrowser *FileBrowserComponent) truncatePath(path string, maxWidth int) string {
@@ -652,13 +733,18 @@ func (fileBrowser *FileBrowserComponent) showDialog(d dialog.Dialog, actionHandl
 }
 
 func (fileBrowser *FileBrowserComponent) openColumnSelectionDialog() {
+	currentActive := fileBrowser.tableContainer.GetColumnSpec()
+	configurableActive := slices.DeleteFunc(slices.Clone(currentActive), func(c *table.Column) bool {
+		return c.Id == table.ColumnLoading.Id
+	})
+
 	d := dialog.NewColumnSelectionDialog(
 		fileBrowser.application,
 		"Configure File Browser Columns",
 		tableColumns,
-		fileBrowser.tableContainer.GetColumnSpec(),
+		configurableActive,
 		func(activeColumns []*table.Column) {
-			fileBrowser.tableContainer.SetActiveColumns(activeColumns)
+			fileBrowser.tableContainer.SetActiveColumns(append([]*table.Column{table.ColumnLoading}, activeColumns...))
 		},
 	)
 	fileBrowser.showDialog(d, func(action dialog.DialogActionId) bool {

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -598,8 +598,6 @@ func (fileBrowser *FileBrowserComponent) startAsyncDiffCalculation() {
 }
 
 func (fileBrowser *FileBrowserComponent) Refresh(debounce bool) {
-	fileBrowser.showMessage(status_message.NewInfoStatusMessage("Refreshing..."))
-
 	_, _, width, _ := fileBrowser.tableContainer.GetLayout().GetRect()
 	if width == 0 {
 		width = 80
@@ -648,7 +646,6 @@ func (fileBrowser *FileBrowserComponent) Refresh(debounce bool) {
 
 				fileBrowser.emit(SelectedTableEntryChangedEvent{fileBrowser.GetSelection()})
 			}
-			fileBrowser.showMessage(status_message.NewInfoStatusMessage(""))
 		})
 	}()
 }

--- a/internal/ui/file_browser/table_container.go
+++ b/internal/ui/file_browser/table_container.go
@@ -18,16 +18,16 @@ import (
 	"github.com/rivo/tview"
 )
 
-func createFileBrowserTable(application *tview.Application) *table.RowSelectionTable[data.FileBrowserEntry] {
+func (fileBrowser *FileBrowserComponent) createFileBrowserTable(application *tview.Application) *table.RowSelectionTable[data.FileBrowserEntry] {
 	tableContainer := table.NewTableContainer[data.FileBrowserEntry](
 		application,
-		fileBrowserEntryTableCellsFunction,
+		fileBrowser.fileBrowserEntryTableCellsFunction,
 		fileBrowserEntrySortFunction,
 	)
 	return tableContainer
 }
 
-func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry *data.FileBrowserEntry) (cells []*tview.TableCell) {
+func (fileBrowser *FileBrowserComponent) fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry *data.FileBrowserEntry) (cells []*tview.TableCell) {
 	statusCellText := determineStatusIndicator(entry)
 	statusCellColor := determineStatusColor(entry)
 	typeCellText := determineTypeCellText(entry)
@@ -40,6 +40,14 @@ func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry 
 		var cellExpansion = 0
 
 		switch column {
+		case table.ColumnLoading:
+			cellAlignment = tview.AlignCenter
+			if entry.IsLoading && fileBrowser.diffLoader != nil && fileBrowser.diffLoader.ShowLoadingSpinner() {
+				cellText = "⟳"
+				cellColor = tcell.ColorYellow
+			} else {
+				cellText = ""
+			}
 		case columnName:
 			cellText = entry.Name
 			stat := entry.GetStat()
@@ -67,12 +75,15 @@ func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry 
 			cellText = determineGIDText(entry)
 			cellColor = tcell.ColorGray
 		case columnDateTime:
-			cellText = entry.GetStat().ModTime().Format(theme.Style.Format.DateTime)
+			stat := entry.GetStat()
+			if stat != nil {
+				cellText = stat.ModTime().Format(theme.Style.Format.DateTime)
+			}
 			switch entry.DiffState {
 			case diff_state.Added, diff_state.Deleted:
 				cellColor = statusCellColor
 			case diff_state.Modified:
-				if entry.RealFile.Stat.ModTime() != entry.SnapshotFiles[0].Stat.ModTime() {
+				if entry.RealFile != nil && len(entry.SnapshotFiles) > 0 && entry.SnapshotFiles[0] != nil && entry.RealFile.Stat.ModTime() != entry.SnapshotFiles[0].Stat.ModTime() {
 					cellColor = statusCellColor
 				} else {
 					cellColor = tcell.ColorWhite
@@ -81,12 +92,15 @@ func fileBrowserEntryTableCellsFunction(row int, columns []*table.Column, entry 
 				cellColor = tcell.ColorGray
 			}
 		case columnSize:
-			cellText = uiutil.StableLengthHumanizedBytes(uint64(entry.GetStat().Size()))
+			stat := entry.GetStat()
+			if stat != nil {
+				cellText = uiutil.StableLengthHumanizedBytes(uint64(stat.Size()))
+			}
 			switch entry.DiffState {
 			case diff_state.Added, diff_state.Deleted:
 				cellColor = statusCellColor
 			case diff_state.Modified:
-				if entry.RealFile.Stat.Size() != entry.SnapshotFiles[0].Stat.Size() {
+				if entry.RealFile != nil && len(entry.SnapshotFiles) > 0 && entry.SnapshotFiles[0] != nil && entry.RealFile.Stat.Size() != entry.SnapshotFiles[0].Stat.Size() {
 					cellColor = statusCellColor
 				} else {
 					cellColor = tcell.ColorWhite

--- a/internal/ui/file_browser/table_container.go
+++ b/internal/ui/file_browser/table_container.go
@@ -40,14 +40,6 @@ func (fileBrowser *FileBrowserComponent) fileBrowserEntryTableCellsFunction(row 
 		var cellExpansion = 0
 
 		switch column {
-		case table.ColumnLoading:
-			cellAlignment = tview.AlignCenter
-			if entry.IsLoading && fileBrowser.diffLoader != nil && fileBrowser.diffLoader.ShowLoadingSpinner() {
-				cellText = "⟳"
-				cellColor = tcell.ColorYellow
-			} else {
-				cellText = ""
-			}
 		case columnName:
 			cellText = entry.Name
 			stat := entry.GetStat()
@@ -62,8 +54,13 @@ func (fileBrowser *FileBrowserComponent) fileBrowserEntryTableCellsFunction(row 
 			cellColor = typeCellColor
 			cellAlignment = tview.AlignCenter
 		case columnDiff:
-			cellText = statusCellText
-			cellColor = statusCellColor
+			if entry.IsLoading && fileBrowser.diffLoader != nil && fileBrowser.diffLoader.ShowLoadingSpinner() {
+				cellText = "⟳"
+				cellColor = tcell.ColorYellow
+			} else {
+				cellText = statusCellText
+				cellColor = statusCellColor
+			}
 			cellAlignment = tview.AlignCenter
 		case columnPermissions:
 			cellText = determinePermissionsText(entry)

--- a/internal/ui/main_page.go
+++ b/internal/ui/main_page.go
@@ -98,7 +98,7 @@ func NewMainPage(application *tview.Application, path string) *MainPage {
 			mainPage.CycleFocus(true)
 		case tcell.KeyF5:
 			snapshotBrowser.Refresh(true)
-			fileBrowser.Refresh()
+			fileBrowser.Refresh(false)
 		default:
 		}
 		return event

--- a/internal/ui/scrollbar/scrollbar_component.go
+++ b/internal/ui/scrollbar/scrollbar_component.go
@@ -177,8 +177,6 @@ func (c *ScrollbarComponent) UpdateLayout() {
 	c.updateTopEndText()
 	c.updateScrollbar()
 	c.updateBottomEndText()
-
-	c.application.ForceDraw()
 }
 
 func (c *ScrollbarComponent) SetOrientation(orientation ScrollBarOrientation) {
@@ -333,7 +331,7 @@ func (c *ScrollbarComponent) determineRuneAndColor(
 }
 
 func (c *ScrollbarComponent) updateScrollbar() {
-	c.application.ForceDraw()
+	// Redraw handled by UpdateLayout QueueUpdateDraw
 }
 
 func (c *ScrollbarComponent) SetWidth(width int) {

--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -357,7 +357,31 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 			filePath = fileEntry.GetRealPath()
 		}
 
-		for _, entry := range entriesToProcess {
+		type diffResult struct {
+			entry *data.SnapshotBrowserEntry
+			state diff_state.DiffState
+		}
+		var batch []diffResult
+
+		pushBatch := func() {
+			if len(batch) == 0 {
+				return
+			}
+			batchCopy := batch
+			batch = nil
+			snapshotBrowser.application.QueueUpdateDraw(func() {
+				if !snapshotBrowser.diffLoader.IsCurrentSequence(seq) {
+					return
+				}
+				for _, res := range batchCopy {
+					res.entry.DiffState = res.state
+					res.entry.IsLoading = false
+					snapshotBrowser.tableContainer.UpdateEntry(res.entry)
+				}
+			})
+		}
+
+		for i, entry := range entriesToProcess {
 			if ctx.Err() != nil {
 				return
 			}
@@ -367,14 +391,12 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 				diffState = entry.Snapshot.DetermineDiffState(filePath)
 			}
 
-			snapshotBrowser.application.QueueUpdateDraw(func() {
-				if !snapshotBrowser.diffLoader.IsCurrentSequence(seq) {
-					return
-				}
-				entry.DiffState = diffState
-				entry.IsLoading = false
-				snapshotBrowser.tableContainer.UpdateEntry(entry)
-			})
+			batch = append(batch, diffResult{entry: entry, state: diffState})
+
+			// Push batch for first few items for instant feedback, then every 10 items, or at the end
+			if i < 5 || len(batch) >= 10 || i == len(entriesToProcess)-1 {
+				pushBatch()
+			}
 		}
 	}()
 }

--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -316,14 +316,7 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 		}
 	}
 
-	if sameSnapshots {
-		for _, entry := range currentEntries {
-			if entry != nil {
-				entry.IsLoading = true
-				snapshotBrowser.tableContainer.UpdateEntry(entry)
-			}
-		}
-	} else {
+	if !sameSnapshots {
 		previousDiffs := make(map[string]diff_state.DiffState)
 		for _, entry := range currentEntries {
 			if entry != nil {
@@ -351,6 +344,28 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 
 	go func() {
 		defer snapshotBrowser.diffLoader.Stop(seq)
+
+		// Debounce rapid scrolling
+		if sameSnapshots {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+
+			// Pre-emptively set loading state in case computation takes a while
+			snapshotBrowser.application.QueueUpdate(func() {
+				if !snapshotBrowser.diffLoader.IsCurrentSequence(seq) {
+					return
+				}
+				for _, entry := range entriesToProcess {
+					if entry != nil {
+						entry.IsLoading = true
+						snapshotBrowser.tableContainer.UpdateEntry(entry)
+					}
+				}
+			})
+		}
 
 		filePath := ""
 		if fileEntry != nil {

--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -352,7 +352,7 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 			case <-time.After(50 * time.Millisecond):
 			}
 
-			// Pre-emptively set loading state in case computation takes a while
+			// Preemptively set loading state in case computation takes a while
 			snapshotBrowser.application.QueueUpdate(func() {
 				if !snapshotBrowser.diffLoader.IsCurrentSequence(seq) {
 					return

--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -87,11 +87,10 @@ var (
 	}
 
 	tableColumns = []*table.Column{
-		table.ColumnLoading, columnName, columnDate, columnDiff, columnUsed, columnRefer, columnRatio, columnClones,
+		columnName, columnDate, columnDiff, columnUsed, columnRefer, columnRatio, columnClones,
 	}
 
 	initialActiveTableColumns = []*table.Column{
-		table.ColumnLoading,
 		columnName,
 		columnDiff,
 		columnDate,
@@ -650,17 +649,14 @@ func (snapshotBrowser *SnapshotBrowserComponent) showDialog(d dialog.Dialog, act
 
 func (snapshotBrowser *SnapshotBrowserComponent) openColumnSelectionDialog() {
 	currentActive := snapshotBrowser.tableContainer.GetColumnSpec()
-	configurableActive := slices.DeleteFunc(slices.Clone(currentActive), func(c *table.Column) bool {
-		return c.Id == table.ColumnLoading.Id
-	})
 
 	d := dialog.NewColumnSelectionDialog(
 		snapshotBrowser.application,
 		"Configure Snapshot Columns",
 		tableColumns,
-		configurableActive,
+		slices.Clone(currentActive),
 		func(activeColumns []*table.Column) {
-			snapshotBrowser.tableContainer.SetActiveColumns(append([]*table.Column{table.ColumnLoading}, activeColumns...))
+			snapshotBrowser.tableContainer.SetActiveColumns(activeColumns)
 		},
 	)
 	snapshotBrowser.showDialog(d, func(action dialog.DialogActionId) bool {

--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"sync/atomic"
 	"time"
 	"zfs-file-history/internal/data"
 	"zfs-file-history/internal/data/diff_state"
@@ -42,8 +41,7 @@ type SnapshotBrowserComponent struct {
 
 	isRestoringSelection bool
 
-	diffCancel context.CancelFunc
-	diffSeq    atomic.Uint64
+	diffLoader *uiutil.DebouncedLoader
 }
 
 type snapshotLoadResult struct {
@@ -89,10 +87,11 @@ var (
 	}
 
 	tableColumns = []*table.Column{
-		columnName, columnDate, columnDiff, columnUsed, columnRefer, columnRatio, columnClones,
+		table.ColumnLoading, columnName, columnDate, columnDiff, columnUsed, columnRefer, columnRatio, columnClones,
 	}
 
 	initialActiveTableColumns = []*table.Column{
+		table.ColumnLoading,
 		columnName,
 		columnDiff,
 		columnDate,
@@ -108,7 +107,18 @@ func NewSnapshotBrowser(application *tview.Application) *SnapshotBrowserComponen
 		selectedSnapshotMemory: uiutil.NewSelectionMemory[data.SnapshotBrowserEntry](),
 	}
 
-	snapshotBrowser.tableContainer = createSnapshotBrowserTable(snapshotBrowser.application)
+	snapshotBrowser.diffLoader = uiutil.NewDebouncedLoader(application, func() {
+		currentSelection := snapshotBrowser.GetSelection()
+		snapshotBrowser.isRestoringSelection = true
+		snapshotBrowser.tableContainer.SetData(snapshotBrowser.tableContainer.GetEntries())
+		if currentSelection != nil {
+			snapshotBrowser.tableContainer.Select(currentSelection)
+		}
+		snapshotBrowser.isRestoringSelection = false
+		snapshotBrowser.updateTableTitle()
+	})
+
+	snapshotBrowser.tableContainer = snapshotBrowser.createSnapshotBrowserTable(snapshotBrowser.application)
 	snapshotBrowser.tableContainer.SetMultiSelect(true)
 
 	snapshotBrowser.container = uiutil.NewLoadingContainer(application, snapshotBrowser.tableContainer.GetLayout(), "Snapshots", "Loading snapshots...")
@@ -278,101 +288,93 @@ func (snapshotBrowser *SnapshotBrowserComponent) updateTableEntries() {
 }
 
 func (snapshotBrowser *SnapshotBrowserComponent) cancelDiffCalculation() {
-	if snapshotBrowser.diffCancel != nil {
-		snapshotBrowser.diffCancel()
-		snapshotBrowser.diffCancel = nil
+	if snapshotBrowser.diffLoader != nil {
+		snapshotBrowser.diffLoader.Cancel()
 	}
 }
 
 func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
-	snapshotBrowser.cancelDiffCalculation()
-
 	snapshots := snapshotBrowser.currentSnapshots
 	fileEntry := snapshotBrowser.currentFileEntry
 
-	// If no snapshots, clear the table instantly
 	if len(snapshots) == 0 {
 		snapshotBrowser.tableContainer.SetData([]*data.SnapshotBrowserEntry{})
 		snapshotBrowser.updateTableTitle()
 		return
 	}
 
-	// Create cancellable context and increment sequence
-	ctx, cancel := context.WithCancel(context.Background())
-	snapshotBrowser.diffCancel = cancel
-	seq := snapshotBrowser.diffSeq.Add(1)
+	ctx, seq := snapshotBrowser.diffLoader.Start()
 
-	// Step 1: Instantly render table with Unknown ("N/A") states
-	initialEntries := make([]*data.SnapshotBrowserEntry, len(snapshots))
-	for i, snap := range snapshots {
-		initialEntries[i] = &data.SnapshotBrowserEntry{
-			Snapshot:  snap,
-			DiffState: diff_state.Unknown,
+	currentEntries := snapshotBrowser.tableContainer.GetEntries()
+	sameSnapshots := len(currentEntries) == len(snapshots)
+	if sameSnapshots {
+		for i, entry := range currentEntries {
+			if entry == nil || entry.Snapshot == nil || entry.Snapshot.Name != snapshots[i].Name {
+				sameSnapshots = false
+				break
+			}
 		}
 	}
-	snapshotBrowser.tableContainer.SetData(initialEntries)
-	snapshotBrowser.updateTableTitle()
 
-	// Get the sorted entries from the table container (determines screen top-to-bottom layout)
-	sortedEntries := snapshotBrowser.tableContainer.GetEntries()
+	if sameSnapshots {
+		for _, entry := range currentEntries {
+			if entry != nil {
+				entry.IsLoading = true
+				snapshotBrowser.tableContainer.UpdateEntry(entry)
+			}
+		}
+	} else {
+		previousDiffs := make(map[string]diff_state.DiffState)
+		for _, entry := range currentEntries {
+			if entry != nil {
+				previousDiffs[entry.Snapshot.Name] = entry.DiffState
+			}
+		}
 
-	// Step 2: Compute actual diffs in background goroutine, processing them in sorted order
+		initialEntries := make([]*data.SnapshotBrowserEntry, len(snapshots))
+		for i, snap := range snapshots {
+			diffState := diff_state.Unknown
+			if oldState, exists := previousDiffs[snap.Name]; exists {
+				diffState = oldState
+			}
+			initialEntries[i] = &data.SnapshotBrowserEntry{
+				Snapshot:  snap,
+				DiffState: diffState,
+				IsLoading: true,
+			}
+		}
+		snapshotBrowser.tableContainer.SetData(initialEntries)
+		snapshotBrowser.updateTableTitle()
+	}
+
+	entriesToProcess := slices.Clone(snapshotBrowser.tableContainer.GetEntries())
+
 	go func() {
+		defer snapshotBrowser.diffLoader.Stop(seq)
+
 		filePath := ""
 		if fileEntry != nil {
 			filePath = fileEntry.GetRealPath()
 		}
 
-		// Keep a local working copy in the exact sorted order
-		localEntries := make([]*data.SnapshotBrowserEntry, len(sortedEntries))
-		for i, entry := range sortedEntries {
-			localEntries[i] = &data.SnapshotBrowserEntry{
-				Snapshot:  entry.Snapshot,
-				DiffState: diff_state.Unknown,
-			}
-		}
-
-		// Closure to safely push local updates to UI thread
-		updateUI := func() {
-			entriesCopy := make([]*data.SnapshotBrowserEntry, len(localEntries))
-			for i, entry := range localEntries {
-				entriesCopy[i] = &data.SnapshotBrowserEntry{
-					Snapshot:  entry.Snapshot,
-					DiffState: entry.DiffState,
-				}
-			}
-
-			snapshotBrowser.application.QueueUpdateDraw(func() {
-				// Discard update if a newer selection calculation has started
-				if seq != snapshotBrowser.diffSeq.Load() {
-					return
-				}
-				snapshotBrowser.tableContainer.SetData(entriesCopy)
-				snapshotBrowser.updateTableTitle()
-			})
-		}
-
-		for i, entry := range localEntries {
-			// Abort immediately if user changed selection and cancelled context
+		for _, entry := range entriesToProcess {
 			if ctx.Err() != nil {
 				return
 			}
 
+			diffState := diff_state.Unknown
 			if filePath != "" {
-				entry.DiffState = entry.Snapshot.DetermineDiffState(filePath)
+				diffState = entry.Snapshot.DetermineDiffState(filePath)
 			}
 
-			// Incremental Redraw Logic:
-			// - First 5 entries: Redraw after each (gives instant feedback on visible entries)
-			// - Remaining entries: Batch update every 10 entries (optimizes UI rendering)
-			// - Final entry: Always push the final update
-			isFirstFew := i < 5
-			isBatchEnd := (i+1)%10 == 0
-			isLast := i == len(localEntries)-1
-
-			if isFirstFew || isBatchEnd || isLast {
-				updateUI()
-			}
+			snapshotBrowser.application.QueueUpdateDraw(func() {
+				if !snapshotBrowser.diffLoader.IsCurrentSequence(seq) {
+					return
+				}
+				entry.DiffState = diffState
+				entry.IsLoading = false
+				snapshotBrowser.tableContainer.UpdateEntry(entry)
+			})
 		}
 	}()
 }
@@ -610,13 +612,18 @@ func (snapshotBrowser *SnapshotBrowserComponent) showDialog(d dialog.Dialog, act
 }
 
 func (snapshotBrowser *SnapshotBrowserComponent) openColumnSelectionDialog() {
+	currentActive := snapshotBrowser.tableContainer.GetColumnSpec()
+	configurableActive := slices.DeleteFunc(slices.Clone(currentActive), func(c *table.Column) bool {
+		return c.Id == table.ColumnLoading.Id
+	})
+
 	d := dialog.NewColumnSelectionDialog(
 		snapshotBrowser.application,
 		"Configure Snapshot Columns",
 		tableColumns,
-		snapshotBrowser.tableContainer.GetColumnSpec(),
+		configurableActive,
 		func(activeColumns []*table.Column) {
-			snapshotBrowser.tableContainer.SetActiveColumns(activeColumns)
+			snapshotBrowser.tableContainer.SetActiveColumns(append([]*table.Column{table.ColumnLoading}, activeColumns...))
 		},
 	)
 	snapshotBrowser.showDialog(d, func(action dialog.DialogActionId) bool {

--- a/internal/ui/snapshot_browser/snapshot_browser.go
+++ b/internal/ui/snapshot_browser/snapshot_browser.go
@@ -376,14 +376,16 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 			state diff_state.DiffState
 		}
 		var batch []diffResult
+		lastDrawTime := time.Now()
 
-		pushBatch := func() {
+		pushBatch := func(forceDraw bool) {
 			if len(batch) == 0 {
 				return
 			}
 			batchCopy := batch
 			batch = nil
-			snapshotBrowser.application.QueueUpdateDraw(func() {
+
+			updateFunc := func() {
 				if !snapshotBrowser.diffLoader.IsCurrentSequence(seq) {
 					return
 				}
@@ -392,7 +394,13 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 					res.entry.IsLoading = false
 					snapshotBrowser.tableContainer.UpdateEntry(res.entry)
 				}
-			})
+			}
+
+			if forceDraw {
+				snapshotBrowser.application.QueueUpdateDraw(updateFunc)
+			} else {
+				snapshotBrowser.application.QueueUpdate(updateFunc)
+			}
 		}
 
 		for i, entry := range entriesToProcess {
@@ -407,9 +415,14 @@ func (snapshotBrowser *SnapshotBrowserComponent) startAsyncDiffCalculation() {
 
 			batch = append(batch, diffResult{entry: entry, state: diffState})
 
-			// Push batch for first few items for instant feedback, then every 10 items, or at the end
-			if i < 5 || len(batch) >= 10 || i == len(entriesToProcess)-1 {
-				pushBatch()
+			now := time.Now()
+			isLast := i == len(entriesToProcess)-1
+			// Draw at most once every 50ms to prevent SSH connection flooding
+			if isLast || now.Sub(lastDrawTime) > 50*time.Millisecond {
+				pushBatch(true)
+				lastDrawTime = now
+			} else if len(batch) >= 10 {
+				pushBatch(false)
 			}
 		}
 	}()

--- a/internal/ui/snapshot_browser/table_container.go
+++ b/internal/ui/snapshot_browser/table_container.go
@@ -32,36 +32,33 @@ func (snapshotBrowser *SnapshotBrowserComponent) createSnapshotBrowserTableCells
 		cellAlign := tview.AlignLeft
 		cellColor := determineBaseTextColor(entry)
 		switch column {
-		case table.ColumnLoading:
-			cellAlign = tview.AlignCenter
-			if entry.IsLoading && snapshotBrowser.diffLoader != nil && snapshotBrowser.diffLoader.ShowLoadingSpinner() {
-				cellText = "⟳"
-				cellColor = tcell.ColorYellow
-			} else {
-				cellText = ""
-			}
 		case columnDate:
 			cellText = entry.Snapshot.Properties.CreationDate.Format(theme.Style.Format.DateTime)
 		case columnName:
 			cellText = entry.Snapshot.Name
 		case columnDiff:
 			cellAlign = tview.AlignCenter
-			switch entry.DiffState {
-			case diff_state.Equal:
-				cellText = "="
-				cellColor = theme.Colors.SnapshotBrowser.Table.State.Equal
-			case diff_state.Deleted:
-				cellText = "+"
-				cellColor = theme.Colors.SnapshotBrowser.Table.State.SnapshotOnly
-			case diff_state.Added:
-				cellText = "-"
-				cellColor = theme.Colors.SnapshotBrowser.Table.State.LocalOnly
-			case diff_state.Modified:
-				cellText = "≠"
-				cellColor = theme.Colors.SnapshotBrowser.Table.State.Modified
-			case diff_state.Unknown:
-				cellText = "N/A"
-				cellColor = theme.Colors.SnapshotBrowser.Table.State.Unknown
+			if entry.IsLoading && snapshotBrowser.diffLoader != nil && snapshotBrowser.diffLoader.ShowLoadingSpinner() {
+				cellText = "⟳"
+				cellColor = tcell.ColorYellow
+			} else {
+				switch entry.DiffState {
+				case diff_state.Equal:
+					cellText = "="
+					cellColor = theme.Colors.SnapshotBrowser.Table.State.Equal
+				case diff_state.Deleted:
+					cellText = "+"
+					cellColor = theme.Colors.SnapshotBrowser.Table.State.SnapshotOnly
+				case diff_state.Added:
+					cellText = "-"
+					cellColor = theme.Colors.SnapshotBrowser.Table.State.LocalOnly
+				case diff_state.Modified:
+					cellText = "≠"
+					cellColor = theme.Colors.SnapshotBrowser.Table.State.Modified
+				default:
+					cellText = "?"
+					cellColor = tcell.ColorGray
+				}
 			}
 		case columnUsed:
 			cellText = uiutil.StableLengthHumanizedBytes(entry.Snapshot.Properties.Used)

--- a/internal/ui/snapshot_browser/table_container.go
+++ b/internal/ui/snapshot_browser/table_container.go
@@ -15,16 +15,16 @@ import (
 	"github.com/rivo/tview"
 )
 
-func createSnapshotBrowserTable(application *tview.Application) *table.RowSelectionTable[data.SnapshotBrowserEntry] {
+func (snapshotBrowser *SnapshotBrowserComponent) createSnapshotBrowserTable(application *tview.Application) *table.RowSelectionTable[data.SnapshotBrowserEntry] {
 	tableContainer := table.NewTableContainer[data.SnapshotBrowserEntry](
 		application,
-		createSnapshotBrowserTableCells,
+		snapshotBrowser.createSnapshotBrowserTableCells,
 		createSnapshotBrowserTableSortFunction,
 	)
 	return tableContainer
 }
 
-func createSnapshotBrowserTableCells(row int, columns []*table.Column, entry *data.SnapshotBrowserEntry) (cells []*tview.TableCell) {
+func (snapshotBrowser *SnapshotBrowserComponent) createSnapshotBrowserTableCells(row int, columns []*table.Column, entry *data.SnapshotBrowserEntry) (cells []*tview.TableCell) {
 	result := []*tview.TableCell{}
 	statusColor := determineStatusColor(entry)
 	for _, column := range columns {
@@ -32,6 +32,14 @@ func createSnapshotBrowserTableCells(row int, columns []*table.Column, entry *da
 		cellAlign := tview.AlignLeft
 		cellColor := determineBaseTextColor(entry)
 		switch column {
+		case table.ColumnLoading:
+			cellAlign = tview.AlignCenter
+			if entry.IsLoading && snapshotBrowser.diffLoader != nil && snapshotBrowser.diffLoader.ShowLoadingSpinner() {
+				cellText = "⟳"
+				cellColor = tcell.ColorYellow
+			} else {
+				cellText = ""
+			}
 		case columnDate:
 			cellText = entry.Snapshot.Properties.CreationDate.Format(theme.Style.Format.DateTime)
 		case columnName:

--- a/internal/ui/snapshot_browser/table_container_test.go
+++ b/internal/ui/snapshot_browser/table_container_test.go
@@ -22,7 +22,8 @@ func TestCreateSnapshotBrowserTableCells_ClonesColumn(t *testing.T) {
 		DiffState: diff_state.Unknown,
 	}
 
-	cells := createSnapshotBrowserTableCells(0, []*table.Column{columnClones}, entry)
+	snapshotBrowser := &SnapshotBrowserComponent{}
+	cells := snapshotBrowser.createSnapshotBrowserTableCells(0, []*table.Column{columnClones}, entry)
 
 	if assert.Len(t, cells, 1) {
 		assert.Equal(t, "42", cells[0].Text)

--- a/internal/ui/table/table_component.go
+++ b/internal/ui/table/table_component.go
@@ -456,7 +456,6 @@ func (c *RowSelectionTable[T]) Select(entry *T) {
 	}
 	c.table.Select(index, 0)
 	c.syncScrollbar()
-	c.application.ForceDraw()
 }
 
 func (c *RowSelectionTable[T]) HasFocus() bool {

--- a/internal/ui/table/table_component.go
+++ b/internal/ui/table/table_component.go
@@ -33,6 +33,12 @@ type Column struct {
 	Alignment int
 }
 
+var ColumnLoading = &Column{
+	Id:        99,
+	Title:     "",
+	Alignment: tview.AlignCenter,
+}
+
 // RowSelectionTable is a table component for the special case where
 // only a single table row can be highlighted at a time instead of a table cell.
 //
@@ -55,6 +61,8 @@ type RowSelectionTable[T RowSelectionTableEntry] struct {
 
 	entries      []*T
 	entriesMutex sync.Mutex
+
+	isUpdatingData bool
 
 	lastSelectedEntry      *T
 	multiSelectEnabled     bool
@@ -142,6 +150,10 @@ func (c *RowSelectionTable[T]) createLayout() {
 
 	table.SetSelectable(true, false)
 	table.SetSelectionChangedFunc(func(row, column int) {
+		if c.isUpdatingData {
+			return
+		}
+
 		selectedEntry := c.GetSelectedEntry()
 
 		if c.lastSelectedEntry != nil && selectedEntry == nil {
@@ -314,12 +326,41 @@ func (c *RowSelectionTable[T]) GetColumnSpec() []*Column {
 }
 
 func (c *RowSelectionTable[T]) SetData(entries []*T) {
+	c.isUpdatingData = true
+	defer func() { c.isUpdatingData = false }()
+
 	c.entriesMutex.Lock()
 	c.entries = entries
 	c.entriesMutex.Unlock()
 	c.SortBy(c.sortByColumn, c.sortInverted)
 	c.cleanupMultiSelection()
 	c.updateTableContents()
+}
+
+func (c *RowSelectionTable[T]) UpdateEntry(entry *T) {
+	c.entriesMutex.Lock()
+	defer c.entriesMutex.Unlock()
+
+	if entry == nil {
+		return
+	}
+
+	index := slices.Index(c.entries, entry)
+	if index < 0 {
+		return
+	}
+
+	cells := c.toTableCells(index, c.columnSpec, entry)
+	for column, cell := range cells {
+		if c.isInMultiSelection(entry) {
+			cell.SetBackgroundColor(theme.Colors.Layout.Table.MultiSelectionBackground)
+			cell.SetTextColor(theme.Colors.Layout.Table.MultiSelectionForeground)
+			cell.SetSelectedStyle(
+				tcell.StyleDefault.Background(theme.Colors.Layout.Table.MultiSelectionBackground),
+			)
+		}
+		c.table.SetCell(index+1, column, cell)
+	}
 }
 
 func (c *RowSelectionTable[T]) SortBy(sortOption *Column, inverted bool) {

--- a/internal/ui/table/table_component.go
+++ b/internal/ui/table/table_component.go
@@ -33,12 +33,6 @@ type Column struct {
 	Alignment int
 }
 
-var ColumnLoading = &Column{
-	Id:        99,
-	Title:     "",
-	Alignment: tview.AlignCenter,
-}
-
 // RowSelectionTable is a table component for the special case where
 // only a single table row can be highlighted at a time instead of a table cell.
 //

--- a/internal/ui/util/data_loader_test.go
+++ b/internal/ui/util/data_loader_test.go
@@ -1,0 +1,235 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataLoader_LoadSuccess(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	loader := NewDataLoader[string](app)
+
+	var startCalled bool
+	var loadCalled bool
+	var loadedData string
+	var mu sync.Mutex
+
+	loader.OnStart(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		startCalled = true
+	})
+	loader.OnLoad(func(data string) {
+		mu.Lock()
+		defer mu.Unlock()
+		loadCalled = true
+		loadedData = data
+	})
+
+	loader.Load(func(ctx context.Context) (string, error) {
+		return "hello data", nil
+	})
+
+	// Wait for async task and QueueUpdateDraw to execute
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	assert.True(t, startCalled)
+	assert.True(t, loadCalled)
+	assert.Equal(t, "hello data", loadedData)
+	mu.Unlock()
+}
+
+func TestDataLoader_LoadQuietly(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	loader := NewDataLoader[string](app)
+
+	var startCalled bool
+	var loadCalled bool
+	var mu sync.Mutex
+
+	loader.OnStart(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		startCalled = true
+	})
+	loader.OnLoad(func(data string) {
+		mu.Lock()
+		defer mu.Unlock()
+		loadCalled = true
+	})
+
+	loader.LoadQuietly(func(ctx context.Context) (string, error) {
+		return "quiet hello", nil
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	assert.False(t, startCalled)
+	assert.True(t, loadCalled)
+	mu.Unlock()
+}
+
+func TestDataLoader_LoadError(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	loader := NewDataLoader[string](app)
+
+	var errCalled bool
+	var returnedErr error
+	var mu sync.Mutex
+
+	loader.OnError(func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		errCalled = true
+		returnedErr = err
+	})
+
+	expectedErr := errors.New("loading error")
+	loader.Load(func(ctx context.Context) (string, error) {
+		return "", expectedErr
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	assert.True(t, errCalled)
+	assert.Equal(t, expectedErr, returnedErr)
+	mu.Unlock()
+}
+
+func TestDataLoader_CancellationAndSequenceTracking(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	loader := NewDataLoader[string](app)
+
+	var firstLoadCalled bool
+	var secondLoadCalled bool
+	var mu sync.Mutex
+
+	loader.OnLoad(func(data string) {
+		mu.Lock()
+		defer mu.Unlock()
+		if data == "first" {
+			firstLoadCalled = true
+		} else if data == "second" {
+			secondLoadCalled = true
+		}
+	})
+
+	// Start first load which takes a bit of time
+	loader.Load(func(ctx context.Context) (string, error) {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+			return "first", nil
+		}
+	})
+
+	// Start second load immediately, which should cancel the first
+	loader.Load(func(ctx context.Context) (string, error) {
+		return "second", nil
+	})
+
+	time.Sleep(150 * time.Millisecond)
+
+	mu.Lock()
+	assert.False(t, firstLoadCalled, "expected first load to be cancelled and ignored")
+	assert.True(t, secondLoadCalled, "expected second load to complete")
+	mu.Unlock()
+}
+
+func TestLoadingContainer(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	content := tview.NewBox()
+	container := NewLoadingContainer(app, content, "Test Container", "Please wait...")
+
+	// Verify initial state
+	assert.False(t, container.isLoading)
+	pageName, frontPage := container.GetFrontPage()
+	assert.Equal(t, LoadingContainerContentPage, pageName)
+	assert.Equal(t, content, frontPage)
+
+	// Set to loading
+	container.SetIsLoading(true)
+	assert.True(t, container.isLoading)
+	pageName, frontPage = container.GetFrontPage()
+	assert.Equal(t, LoadingContainerLoadingPage, pageName)
+
+	// Wait a bit to let the loading view ticker run and render frames
+	time.Sleep(150 * time.Millisecond)
+
+	// Calling SetIsLoading again with same value should do nothing
+	container.SetIsLoading(true)
+	assert.True(t, container.isLoading)
+
+	// Set back to not loading
+	container.SetIsLoading(false)
+	assert.False(t, container.isLoading)
+	pageName, frontPage = container.GetFrontPage()
+	assert.Equal(t, LoadingContainerContentPage, pageName)
+	assert.Equal(t, content, frontPage)
+}
+
+func TestLoadingView_EdgeCases(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	loadingView := NewLoadingView(app, "Title", "Message")
+
+	// Start once
+	loadingView.Start()
+	assert.NotNil(t, loadingView.cancel)
+
+	// Start again (should return early since cancel != nil)
+	loadingView.Start()
+
+	// Stop
+	loadingView.Stop()
+	assert.Nil(t, loadingView.cancel)
+
+	// Stop again (should do nothing since cancel == nil)
+	loadingView.Stop()
+
+	// Test Start and ticker fire with nil app
+	loadingViewNilApp := NewLoadingView(nil, "Title", "Message")
+	loadingViewNilApp.Start()
+	time.Sleep(150 * time.Millisecond)
+	loadingViewNilApp.Stop()
+}

--- a/internal/ui/util/debounced_loader.go
+++ b/internal/ui/util/debounced_loader.go
@@ -16,6 +16,7 @@ type DebouncedLoader struct {
 	sequenceCounter    atomic.Uint64
 	timer              *time.Timer
 	showLoadingSpinner bool
+	isLoading          bool
 	mutex              sync.Mutex
 }
 
@@ -35,13 +36,15 @@ func (l *DebouncedLoader) Start() (context.Context, uint64) {
 	l.cancelContext = cancel
 	seq := l.sequenceCounter.Add(1)
 	l.showLoadingSpinner = false
+	l.isLoading = true
 
 	l.timer = time.AfterFunc(100*time.Millisecond, func() {
 		l.application.QueueUpdateDraw(func() {
-			if seq != l.sequenceCounter.Load() {
+			l.mutex.Lock()
+			if seq != l.sequenceCounter.Load() || !l.isLoading {
+				l.mutex.Unlock()
 				return
 			}
-			l.mutex.Lock()
 			l.showLoadingSpinner = true
 			l.mutex.Unlock()
 			l.onShowSpinner()
@@ -51,23 +54,23 @@ func (l *DebouncedLoader) Start() (context.Context, uint64) {
 }
 
 func (l *DebouncedLoader) Stop(seq uint64) {
-	l.application.QueueUpdateDraw(func() {
-		if seq != l.sequenceCounter.Load() {
-			return
-		}
-		l.mutex.Lock()
-		defer l.mutex.Unlock()
-		if l.timer != nil {
-			l.timer.Stop()
-			l.timer = nil
-		}
-	})
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if seq != l.sequenceCounter.Load() {
+		return
+	}
+	l.isLoading = false
+	if l.timer != nil {
+		l.timer.Stop()
+		l.timer = nil
+	}
 }
 
 func (l *DebouncedLoader) Cancel() {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
+	l.isLoading = false
 	if l.cancelContext != nil {
 		l.cancelContext()
 		l.cancelContext = nil

--- a/internal/ui/util/debounced_loader.go
+++ b/internal/ui/util/debounced_loader.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +16,7 @@ type DebouncedLoader struct {
 	sequenceCounter    atomic.Uint64
 	timer              *time.Timer
 	showLoadingSpinner bool
+	mutex              sync.Mutex
 }
 
 func NewDebouncedLoader(application *tview.Application, onShowSpinner func()) *DebouncedLoader {
@@ -26,6 +28,9 @@ func NewDebouncedLoader(application *tview.Application, onShowSpinner func()) *D
 
 func (l *DebouncedLoader) Start() (context.Context, uint64) {
 	l.Cancel()
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	l.cancelContext = cancel
 	seq := l.sequenceCounter.Add(1)
@@ -36,7 +41,9 @@ func (l *DebouncedLoader) Start() (context.Context, uint64) {
 			if seq != l.sequenceCounter.Load() {
 				return
 			}
+			l.mutex.Lock()
 			l.showLoadingSpinner = true
+			l.mutex.Unlock()
 			l.onShowSpinner()
 		})
 	})
@@ -48,6 +55,8 @@ func (l *DebouncedLoader) Stop(seq uint64) {
 		if seq != l.sequenceCounter.Load() {
 			return
 		}
+		l.mutex.Lock()
+		defer l.mutex.Unlock()
 		if l.timer != nil {
 			l.timer.Stop()
 			l.timer = nil
@@ -56,6 +65,9 @@ func (l *DebouncedLoader) Stop(seq uint64) {
 }
 
 func (l *DebouncedLoader) Cancel() {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	if l.cancelContext != nil {
 		l.cancelContext()
 		l.cancelContext = nil
@@ -71,5 +83,7 @@ func (l *DebouncedLoader) IsCurrentSequence(seq uint64) bool {
 }
 
 func (l *DebouncedLoader) ShowLoadingSpinner() bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
 	return l.showLoadingSpinner
 }

--- a/internal/ui/util/debounced_loader.go
+++ b/internal/ui/util/debounced_loader.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/rivo/tview"
+)
+
+type DebouncedLoader struct {
+	application        *tview.Application
+	onShowSpinner      func()
+	cancelContext      context.CancelFunc
+	sequenceCounter    atomic.Uint64
+	timer              *time.Timer
+	showLoadingSpinner bool
+}
+
+func NewDebouncedLoader(application *tview.Application, onShowSpinner func()) *DebouncedLoader {
+	return &DebouncedLoader{
+		application:   application,
+		onShowSpinner: onShowSpinner,
+	}
+}
+
+func (l *DebouncedLoader) Start() (context.Context, uint64) {
+	l.Cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	l.cancelContext = cancel
+	seq := l.sequenceCounter.Add(1)
+	l.showLoadingSpinner = false
+
+	l.timer = time.AfterFunc(100*time.Millisecond, func() {
+		l.application.QueueUpdateDraw(func() {
+			if seq != l.sequenceCounter.Load() {
+				return
+			}
+			l.showLoadingSpinner = true
+			l.onShowSpinner()
+		})
+	})
+	return ctx, seq
+}
+
+func (l *DebouncedLoader) Stop(seq uint64) {
+	l.application.QueueUpdateDraw(func() {
+		if seq != l.sequenceCounter.Load() {
+			return
+		}
+		if l.timer != nil {
+			l.timer.Stop()
+			l.timer = nil
+		}
+	})
+}
+
+func (l *DebouncedLoader) Cancel() {
+	if l.cancelContext != nil {
+		l.cancelContext()
+		l.cancelContext = nil
+	}
+	if l.timer != nil {
+		l.timer.Stop()
+		l.timer = nil
+	}
+}
+
+func (l *DebouncedLoader) IsCurrentSequence(seq uint64) bool {
+	return seq == l.sequenceCounter.Load()
+}
+
+func (l *DebouncedLoader) ShowLoadingSpinner() bool {
+	return l.showLoadingSpinner
+}

--- a/internal/ui/util/debounced_loader_test.go
+++ b/internal/ui/util/debounced_loader_test.go
@@ -93,6 +93,38 @@ func TestDebouncedLoader_ShowSpinner(t *testing.T) {
 	loader.mutex.Unlock()
 }
 
+func TestDebouncedLoader_SequenceMismatchAndEdgeCases(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	loader := NewDebouncedLoader(app, func() {})
+
+	_, seq := loader.Start()
+
+	// 1. Try to stop with a sequence mismatch
+	loader.Stop(seq - 1)
+
+	// Since sequence mismatch occurred, the loader is still loading the original sequence
+	loader.mutex.Lock()
+	if !loader.isLoading {
+		t.Fatal("expected loader to still be loading despite mismatched Stop call")
+	}
+	loader.mutex.Unlock()
+
+	// 2. Start a new loader sequence to cause a mismatch on the original timer
+	_, seq2 := loader.Start()
+
+	// Wait for the timer of the first start or second start to fire
+	time.Sleep(150 * time.Millisecond)
+
+	// Verify that the second sequence loader stopped normally
+	loader.Stop(seq2)
+	loader.Stop(seq2) // Stopping again when timer is already nil/stopped is a safe no-op
+}
+
 func BenchmarkDebouncedLoader_StartCancel(b *testing.B) {
 	app := tview.NewApplication()
 	simScreen := tcell.NewSimulationScreen("")

--- a/internal/ui/util/debounced_loader_test.go
+++ b/internal/ui/util/debounced_loader_test.go
@@ -1,0 +1,109 @@
+package util
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func TestDebouncedLoader_StartCancel(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	var showSpinnerCalled bool
+	var mu sync.Mutex
+
+	loader := NewDebouncedLoader(app, func() {
+		mu.Lock()
+		defer mu.Unlock()
+		showSpinnerCalled = true
+	})
+
+	ctx, seq := loader.Start()
+	if ctx == nil {
+		t.Fatal("expected context to be non-nil")
+	}
+	if seq == 0 {
+		t.Fatal("expected sequence to be > 0")
+	}
+	if !loader.IsCurrentSequence(seq) {
+		t.Fatal("expected sequence to be current")
+	}
+
+	loader.Cancel()
+	select {
+	case <-ctx.Done():
+		// expected
+	default:
+		t.Fatal("expected context to be cancelled")
+	}
+
+	mu.Lock()
+	if showSpinnerCalled {
+		t.Fatal("expected spinner to not be shown")
+	}
+	mu.Unlock()
+}
+
+func TestDebouncedLoader_ShowSpinner(t *testing.T) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	var showSpinnerCalled bool
+	var mu sync.Mutex
+
+	loader := NewDebouncedLoader(app, func() {
+		mu.Lock()
+		defer mu.Unlock()
+		showSpinnerCalled = true
+	})
+
+	_, seq := loader.Start()
+
+	// Wait for the timer to fire and the queued update to execute
+	time.Sleep(200 * time.Millisecond)
+
+	if !loader.ShowLoadingSpinner() {
+		t.Fatal("expected ShowLoadingSpinner to be true")
+	}
+
+	mu.Lock()
+	if !showSpinnerCalled {
+		t.Fatal("expected onShowSpinner to be called")
+	}
+	mu.Unlock()
+
+	loader.Stop(seq)
+
+	time.Sleep(50 * time.Millisecond)
+
+	loader.mutex.Lock()
+	if loader.timer != nil {
+		t.Fatal("expected timer to be nil after Stop")
+	}
+	loader.mutex.Unlock()
+}
+
+func BenchmarkDebouncedLoader_StartCancel(b *testing.B) {
+	app := tview.NewApplication()
+	simScreen := tcell.NewSimulationScreen("")
+	app.SetScreen(simScreen)
+	go app.Run()
+	defer app.Stop()
+
+	loader := NewDebouncedLoader(app, func() {})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		loader.Start()
+		loader.Cancel()
+	}
+}


### PR DESCRIPTION
## Description

This pull request resolves the UI freezing/lag that occurred when changing selections or refreshing paths in the file history interface. It also completely eliminates visual flickering (e.g. flashing `N/A`) during directory watcher events, F5 refreshes, or selection changes.

It implements unconditional carry-over of diff states in both tables, and introduces a hardcoded, non-configurable **Loading Status Column** to indicate that background calculations are currently in progress.

A **100ms debounce timer** has been added to the loading spinner rendering. If the background computation completes in under 100ms, the sync spinner (`⟳`) is never shown. This prevents the loading spinner itself from flickering or flashing briefly during fast updates.

---

## Key Changes

### 1. Hardcoded Loading Status Column (Column 0)
* Added a hardcoded `columnLoading` (ID `99`) as the first column in both the File Browser and the Snapshot Browser.
* Excluded this column from the column customization dialog to prevent the user from reordering, hiding, or deleting it.
* Renders a rotating sync symbol (`⟳`) next to entries currently undergoing background diff calculation, which vanishes once computation finishes.

### 2. Debounced Loading Spinner
* Introduced a shared `DebouncedLoader` utility that manages background calculation sequences, context cancellation, and the `100ms` debounce timer.
* The rotating sync symbol (`⟳`) is only rendered when an entry's diff is loading AND `DebouncedLoader.ShowLoadingSpinner()` is true.
* The spinner becomes visible only if the background computation takes longer than `100ms`.

### 3. Refactored Cell Rendering Scope
* Refactored cell rendering functions into component methods on `FileBrowserComponent` and `SnapshotBrowserComponent` to access `ShowLoadingSpinner()`.

### 4. Unconditional Carry-over of Diff States
* Removed the previous conditional context checks (`fileHasNotChanged` and `snapshotHasNotChanged`).
* Both tables now unconditionally carry over their last known diff states when refreshing or updating selections, preventing `N/A` from flashing during active directory updates or file selection changes.
* Files and snapshots naturally default to `N/A` only if they represent newly added entries or if the directory path changes.

### 5. Asynchronous Diff Computation
* Both components calculate diff states in background goroutines rather than blocking the main UI thread.
* Updates are pushed to the UI incrementally: at most once every `100ms` (or once at the end if the total directory/dataset computation is fast), avoiding redundant table rebuilds.

### 6. Thread-Safe File Watcher Updates
* Wrapped the background directory watcher `action` callback in `fileBrowser.application.QueueUpdateDraw()`, resolving data races where the background thread cleared/wrote table data during rendering.

---

## Files Modified
* [internal/data/file_browser_entry.go](file:///home/markus/GolandProjects/zfs-file-history/internal/data/file_browser_entry.go)
* [internal/data/snapshot_browser_entry.go](file:///home/markus/GolandProjects/zfs-file-history/internal/data/snapshot_browser_entry.go)
* [internal/ui/dialog/restore_file_progress_dialog.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/dialog/restore_file_progress_dialog.go)
* [internal/ui/file_browser/file_browser.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/file_browser/file_browser.go)
* [internal/ui/file_browser/table_container.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/file_browser/table_container.go)
* [internal/ui/snapshot_browser/snapshot_browser.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/snapshot_browser/snapshot_browser.go)
* [internal/ui/snapshot_browser/table_container.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/snapshot_browser/table_container.go)
* [internal/ui/snapshot_browser/table_container_test.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/snapshot_browser/table_container_test.go)
* [internal/ui/table/table_component.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/table/table_component.go)
* [internal/ui/util/debounced_loader.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/util/debounced_loader.go)

## Verification
* Unit tests successfully verified (`go test ./...`).
* Build compilation verified (`just build`).
* Manually tested scrolling and directory file modifications: UI is responsive, refreshes are flicker-free, and status indicators cleanly update.
