### PR TITLE
Dynamic Shortcut Helper Height Auto-Adaptation

### DIFF
--- a/internal/ui/main_page.go
+++ b/internal/ui/main_page.go
@@ -306,6 +306,9 @@ func (mainPage *MainPage) createLayout() *tview.Flex {
 	mainPage.header = header
 
 	shortcutMap := shortcut_helper.NewShortcutMap(mainPage.application)
+	shortcutMap.SetOnHeightChanged(func(height int) {
+		mainPageLayout.ResizeItem(shortcutMap.GetLayout(), height, 0)
+	})
 	mainPageLayout.AddItem(shortcutMap.GetLayout(), 1, 0, false)
 	mainPage.shortcutMap = shortcutMap
 

--- a/internal/ui/shortcut_helper/shortcut_map_component.go
+++ b/internal/ui/shortcut_helper/shortcut_map_component.go
@@ -2,11 +2,14 @@ package shortcut_helper
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"zfs-file-history/internal/ui/theme"
 	"zfs-file-history/internal/ui/txwidgets"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"golang.org/x/term"
 )
 
 type ShortcutEntry struct {
@@ -19,6 +22,7 @@ type ShortcutMapComponent struct {
 
 	layout                  *tview.Flex
 	shortcutEntriesTextView *tview.TextView
+	onHeightChanged         func(height int)
 
 	ShortCutEntries []ShortcutEntry
 }
@@ -41,31 +45,118 @@ func (sm *ShortcutMapComponent) createLayout() {
 	shortcutEntriesTextView.SetBorderPadding(0, 0, 1, 1)
 	shortcutEntriesTextView.SetTextAlign(tview.AlignLeft)
 
+	// Set draw func to monitor and dynamically resize height on line wraps
+	shortcutEntriesTextView.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+		lines := sm.CalculateHeightForWidth(width)
+		if height != lines {
+			if sm.onHeightChanged != nil {
+				go func() {
+					sm.application.QueueUpdateDraw(func() {
+						if sm.onHeightChanged != nil {
+							sm.onHeightChanged(lines)
+						}
+					})
+				}()
+			}
+		}
+		return x, y, width, height
+	})
+
 	layout.AddItem(shortcutEntriesTextView, 0, 1, false)
 
 	sm.shortcutEntriesTextView = shortcutEntriesTextView
 	sm.layout = layout
 }
 
+func (sm *ShortcutMapComponent) SetOnHeightChanged(f func(height int)) {
+	sm.onHeightChanged = f
+}
+
 func (sm *ShortcutMapComponent) SetEntries(entries []ShortcutEntry) {
 	sm.ShortCutEntries = entries
 	var statusText string
 	for _, entry := range entries {
-		// comma separated list:
-		shortCutsText := strings.Join(entry.KeyCombo, "|")
+		// comma separated list joined with non-breaking vertical line
+		shortCutsText := strings.Join(entry.KeyCombo, "\u01c0")
 		shortcuts := txwidgets.Span(theme.Colors.ShortcutMap.KeyCombo, "[%s]", shortCutsText)
-		name := txwidgets.Span(theme.Colors.ShortcutMap.Name, "%s", entry.Name)
-		statusText += fmt.Sprintf("%s: %s  ", shortcuts, name)
+		nameText := strings.ReplaceAll(entry.Name, " ", "\u00a0")
+		name := txwidgets.Span(theme.Colors.ShortcutMap.Name, "%s", nameText)
+		statusText += fmt.Sprintf("%s:\u00a0%s  ", shortcuts, name)
 	}
 	sm.shortcutEntriesTextView.SetText(statusText)
+	if sm.onHeightChanged != nil {
+		lines := sm.CalculateHeightFromTerminal()
+		sm.onHeightChanged(lines)
+	}
 	sm.application.ForceDraw()
 }
 
 func (sm *ShortcutMapComponent) Clear() {
 	sm.shortcutEntriesTextView.SetText("")
+	if sm.onHeightChanged != nil {
+		sm.onHeightChanged(1)
+	}
 	sm.application.ForceDraw()
 }
 
 func (sm *ShortcutMapComponent) GetLayout() *tview.Flex {
 	return sm.layout
+}
+
+func (sm *ShortcutMapComponent) CalculateHeightFromTerminal() int {
+	_, _, width, _ := sm.layout.GetRect()
+	if width <= 0 {
+		var err error
+		width, _, err = term.GetSize(int(os.Stdout.Fd()))
+		if err != nil || width <= 0 {
+			width = 80
+		}
+	}
+	return sm.CalculateHeightForWidth(width)
+}
+
+func (sm *ShortcutMapComponent) CalculateHeightForWidth(width int) int {
+	availableWidth := width - 2 // padding
+	if availableWidth <= 0 {
+		availableWidth = 80
+	}
+
+	var visibleText string
+	for _, entry := range sm.ShortCutEntries {
+		shortCutsText := strings.Join(entry.KeyCombo, "\u01c0")
+		nameText := strings.ReplaceAll(entry.Name, " ", "\u00a0")
+		visibleText += fmt.Sprintf("[%s]:\u00a0%s  ", shortCutsText, nameText)
+	}
+
+	visibleText = strings.TrimSpace(visibleText)
+	if len(visibleText) == 0 {
+		return 1
+	}
+
+	runes := []rune(visibleText)
+	lines := 1
+	currentLineLength := 0
+
+	i := 0
+	for i < len(runes) {
+		if runes[i] == ' ' {
+			currentLineLength++
+			i++
+		} else {
+			wordStart := i
+			for i < len(runes) && runes[i] != ' ' {
+				i++
+			}
+			wordWidth := i - wordStart
+
+			if currentLineLength+wordWidth > availableWidth {
+				lines++
+				currentLineLength = wordWidth
+			} else {
+				currentLineLength += wordWidth
+			}
+		}
+	}
+
+	return lines
 }

--- a/internal/ui/shortcut_helper/shortcut_map_component_test.go
+++ b/internal/ui/shortcut_helper/shortcut_map_component_test.go
@@ -1,0 +1,141 @@
+package shortcut_helper
+
+import (
+	"testing"
+	"zfs-file-history/internal/ui/theme"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewShortcutMap(t *testing.T) {
+	app := tview.NewApplication()
+	sm := NewShortcutMap(app)
+
+	assert.NotNil(t, sm)
+	assert.NotNil(t, sm.GetLayout())
+	assert.NotNil(t, sm.shortcutEntriesTextView)
+}
+
+func TestSetOnHeightChanged(t *testing.T) {
+	app := tview.NewApplication()
+	sm := NewShortcutMap(app)
+
+	heightCalled := -1
+	sm.SetOnHeightChanged(func(height int) {
+		heightCalled = height
+	})
+
+	assert.NotNil(t, sm.onHeightChanged)
+
+	entries := []ShortcutEntry{
+		{KeyCombo: []string{"ctrl+q"}, Name: "Quit"},
+	}
+
+	sm.SetEntries(entries)
+	assert.Greater(t, heightCalled, 0)
+}
+
+func TestSetEntriesAndClear(t *testing.T) {
+	// Setup custom theme colors if needed (or fallback to default theme color struct)
+	theme.Colors.ShortcutMap.KeyCombo = 0
+	theme.Colors.ShortcutMap.Name = 0
+
+	app := tview.NewApplication()
+	sm := NewShortcutMap(app)
+
+	entries := []ShortcutEntry{
+		{KeyCombo: []string{"⭾", "shift+⭾"}, Name: "Cycle focus"},
+		{KeyCombo: []string{"ctrl+q"}, Name: "Quit"},
+	}
+
+	sm.SetEntries(entries)
+
+	assert.Equal(t, entries, sm.ShortCutEntries)
+
+	text := sm.shortcutEntriesTextView.GetText(false)
+	// Verify formatting contains non-breaking spaces (\u00a0) inside cycle focus name
+	assert.Contains(t, text, "Cycle\u00a0focus")
+	// Verify multiple combos joined with non-breaking dental click (\u01c0)
+	assert.Contains(t, text, "⭾\u01c0shift+⭾")
+
+	sm.Clear()
+	assert.Empty(t, sm.shortcutEntriesTextView.GetText(false))
+}
+
+func TestCalculateHeightForWidth(t *testing.T) {
+	app := tview.NewApplication()
+	sm := NewShortcutMap(app)
+
+	// No entries
+	sm.ShortCutEntries = nil
+	assert.Equal(t, 1, sm.CalculateHeightForWidth(80))
+
+	// Short entry
+	sm.ShortCutEntries = []ShortcutEntry{
+		{KeyCombo: []string{"ctrl+q"}, Name: "Quit"},
+	}
+
+	// "[ctrl+q]:\u00a0Quit  " -> trimmed: "[ctrl+q]:\u00a0Quit" (14 runes)
+	// availableWidth = 30 - 2 = 28 -> fits (1 line)
+	// availableWidth = 10 - 2 = 8 -> wraps (2 lines because word length 14 > 8)
+	assert.Equal(t, 1, sm.CalculateHeightForWidth(30))
+	assert.Equal(t, 2, sm.CalculateHeightForWidth(10))
+
+	// Multi-combo entry with Unicode symbols
+	sm.ShortCutEntries = []ShortcutEntry{
+		{KeyCombo: []string{"⭾", "shift+⭾"}, Name: "Cycle focus"},
+	}
+	// "[⭾\u01c0shift+⭾]:\u00a0Cycle\u00a0focus  " -> trimmed length: 24 runes (including multi-byte symbols counted as 1)
+	// availableWidth = 30 - 2 = 28 -> fits (1 line)
+	// availableWidth = 20 - 2 = 18 -> wraps (2 lines because word length 24 > 18)
+	assert.Equal(t, 1, sm.CalculateHeightForWidth(30))
+	assert.Equal(t, 2, sm.CalculateHeightForWidth(20))
+
+	// Long list of entries
+	sm.ShortCutEntries = []ShortcutEntry{
+		{KeyCombo: []string{"⭾", "shift+⭾"}, Name: "Cycle focus"},
+		{KeyCombo: []string{"F5"}, Name: "Refresh"},
+		{KeyCombo: []string{"ctrl+q"}, Name: "Quit"},
+		{KeyCombo: []string{"↑", "k"}, Name: "Move up"},
+		{KeyCombo: []string{"↓", "j"}, Name: "Move down"},
+	}
+
+	// With very large terminal width, should fit in 1 line
+	assert.Equal(t, 1, sm.CalculateHeightForWidth(200))
+	// With narrow terminal width, should wrap into multiple lines
+	assert.Greater(t, sm.CalculateHeightForWidth(40), 1)
+}
+
+func TestCalculateHeightFromTerminal(t *testing.T) {
+	app := tview.NewApplication()
+	sm := NewShortcutMap(app)
+
+	sm.ShortCutEntries = []ShortcutEntry{
+		{KeyCombo: []string{"ctrl+q"}, Name: "Quit"},
+	}
+
+	// Height from terminal is calculated. Even if it falls back to 80 width,
+	// it should return a valid height >= 1
+	height := sm.CalculateHeightFromTerminal()
+	assert.GreaterOrEqual(t, height, 1)
+}
+
+func TestDrawFuncHeightResize(t *testing.T) {
+	app := tview.NewApplication()
+	sm := NewShortcutMap(app)
+
+	sm.SetOnHeightChanged(func(height int) {
+		t.Logf("Height changed to %d", height)
+	})
+
+	sm.ShortCutEntries = []ShortcutEntry{
+		{KeyCombo: []string{"ctrl+q"}, Name: "Quit"},
+	}
+
+	drawFunc := sm.shortcutEntriesTextView.GetDrawFunc()
+	assert.NotNil(t, drawFunc)
+
+	// Invoke the DrawFunc to trigger size verification logic
+	drawFunc(nil, 0, 0, 8, 1)
+}


### PR DESCRIPTION
This PR introduces dynamic height auto-adaptation for the TUI shortcut helper panel at the bottom of the interface. It ensures that all defined shortcuts are visible at all times, handling line wraps and terminal window resizing cleanly in a one-shot computation without clipping, entry splitting, or startup flickering.

---

## Features & Implementation Details

### 1. Custom Word-Wrapping Height Math
- Implemented a precise word-wrapping line counter (`CalculateHeightForWidth`) inside `ShortcutMapComponent` ([shortcut_map_component.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/shortcut_helper/shortcut_map_component.go)) that operates on a slice of runes.
- Simulates word boundary wrap locations to calculate the exact height required for the shortcut text block in terminal cells.

### 2. Unbreakable Shortcut Entries (NBSP & Dental Click separators)
- To prevent keyboard key combos and action names from being split across line breaks (which looks messy and splits definition from label):
  - Spaces within each shortcut entry are replaced with **Unicode Non-Breaking Spaces** (`\u00a0`).
  - Vertical bars separating multiple key combos for a single action (e.g. `⭾|shift+⭾`) are joined using the **Unicode Latin Letter Dental Click** (`\u01c0` / `ǀ`), which renders identically to a vertical bar but is treated as an alphabetic character by the Unicode wrapping algorithm (UAX #14).
  - Regular spaces are used exclusively between different entries, forcing wrap boundaries only at full shortcut entry units.

### 3. Flicker-Free Initial Sizing
- Retrieves the console dimensions directly from the OS on startup using `golang.org/x/term` (`term.GetSize(int(os.Stdout.Fd()))`) as a fallback if the layout hasn't been drawn yet.
- Resizes the shortcut map item in the parent `Flex` *prior* to the first draw loop, rendering the first frame perfectly with zero layout flickering.

### 4. Smooth Terminal Resize Support
- Overrides `SetDrawFunc` on the underlying text view to monitor real-time dimension shifts during terminal window resizes.
- If the layout width shifts and triggers wrapping adjustments, the parent `Flex` layout (`mainPageLayout` in [main_page.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/main_page.go)) is updated asynchronously using `application.QueueUpdateDraw` from a background goroutine, avoiding deadlocks or recursion during the draw loop.

---

## Validation

- Verified that all unit tests (`go test ./...`) compile and pass successfully.
- Manually tested that layout is stable across different window sizes and scales instantly without incremental sizing steps.
