### PR TITLE
Dialog UI Sizing, UX, and Alignment Improvements

### DIFF
--- a/internal/ui/dialog/column_selection_dialog.go
+++ b/internal/ui/dialog/column_selection_dialog.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"slices"
+	"unicode/utf8"
 	"zfs-file-history/internal/ui/shortcut_helper"
 	"zfs-file-history/internal/ui/table"
 	"zfs-file-history/internal/ui/util"
@@ -97,7 +98,25 @@ func (d *ColumnSelectionDialog) createLayout() {
 		return action, event
 	})
 
-	d.layout = createModal(d.title, content, 70, 20)
+	maxColWidth := 0
+	for _, col := range d.allColumns {
+		if col != nil {
+			if l := utf8.RuneCountInString(col.Title); l > maxColWidth {
+				maxColWidth = l
+			}
+		}
+	}
+
+	extraWidth := 2 * (maxColWidth + 4)
+	staticHeight := 1 + len(d.allColumns) + 2
+
+	width, height := CalculateDialogSize(DialogSizeConstraints{
+		Title:             d.title,
+		ExtraContentWidth: extraWidth,
+		StaticHeight:      staticHeight,
+	})
+
+	d.layout = createModal(d.title, content, width, height)
 	d.layout.SetInputCapture(d.captureInput)
 }
 

--- a/internal/ui/dialog/column_selection_dialog_test.go
+++ b/internal/ui/dialog/column_selection_dialog_test.go
@@ -1,0 +1,92 @@
+package dialog
+
+import (
+	"testing"
+	"zfs-file-history/internal/ui/table"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeAvailableColumns(t *testing.T) {
+	all := []*table.Column{
+		{Id: table.ColumnId(1), Title: "Col 1"},
+		{Id: table.ColumnId(2), Title: "Col 2"},
+		{Id: table.ColumnId(3), Title: "Col 3"},
+	}
+	active := []*table.Column{
+		{Id: table.ColumnId(2), Title: "Col 2"},
+	}
+
+	available := computeAvailableColumns(all, active)
+	assert.Len(t, available, 2)
+	assert.Equal(t, table.ColumnId(1), available[0].Id)
+	assert.Equal(t, table.ColumnId(3), available[1].Id)
+}
+
+func TestColumnSelectionDialog(t *testing.T) {
+	app := tview.NewApplication()
+	all := []*table.Column{
+		{Id: table.ColumnId(1), Title: "Col 1"},
+		{Id: table.ColumnId(2), Title: "Col 2"},
+	}
+	active := []*table.Column{
+		{Id: table.ColumnId(1), Title: "Col 1"},
+	}
+
+	d := NewColumnSelectionDialog(app, "Column Selection", all, active, func(activeColumns []*table.Column) {})
+	assert.Equal(t, "ColumnSelectionDialog", d.GetName())
+	assert.NotNil(t, d.GetLayout())
+	assert.NotNil(t, d.GetActionChannel())
+}
+
+func TestColumnSelectionDialog_Actions(t *testing.T) {
+	app := tview.NewApplication()
+	all := []*table.Column{
+		{Id: table.ColumnId(1), Title: "Col 1"},
+		{Id: table.ColumnId(2), Title: "Col 2"},
+		{Id: table.ColumnId(3), Title: "Col 3"},
+	}
+	active := []*table.Column{
+		{Id: table.ColumnId(1), Title: "Col 1"},
+		{Id: table.ColumnId(2), Title: "Col 2"},
+	}
+
+	changeCalled := false
+	d := NewColumnSelectionDialog(app, "Column Selection", all, active, func(activeColumns []*table.Column) {
+		changeCalled = true
+	})
+
+	// Test Close
+	go func() {
+		d.Close()
+	}()
+	action := <-d.GetActionChannel()
+	assert.Equal(t, DialogCloseActionId, action)
+
+	// Test add selected available column
+	d.addSelectedAvailableColumn()
+	assert.True(t, changeCalled)
+	assert.Len(t, d.activeColumns, 3)
+
+	// Reset changeCalled
+	changeCalled = false
+
+	// Test remove selected active column
+	d.activeTable.Select(1, 0)
+	d.removeSelectedActiveColumn()
+	assert.True(t, changeCalled)
+	assert.Len(t, d.activeColumns, 2)
+
+	// Reset changeCalled
+	changeCalled = false
+
+	// Test move active column up/down
+	d.activeTable.Select(1, 0)
+	d.moveActiveColumnUp()
+	assert.True(t, changeCalled)
+
+	changeCalled = false
+	d.moveActiveColumnDown()
+	assert.True(t, changeCalled)
+}

--- a/internal/ui/dialog/delete_file_dialog.go
+++ b/internal/ui/dialog/delete_file_dialog.go
@@ -22,7 +22,5 @@ func NewDeleteFileDialog(application *tview.Application, file *data.FileBrowserE
 		" 🗑️ Delete File ",
 		fmt.Sprintf("Delete '%s'?", file.Name),
 		buildConfirmDialogOptions(DeleteFileDialogDeleteFileActionId, localization.LocalizationCommonDelete, file.HasReal(), DialogSeverityDanger),
-		50,
-		6,
 	)
 }

--- a/internal/ui/dialog/delete_snapshot_dialog.go
+++ b/internal/ui/dialog/delete_snapshot_dialog.go
@@ -21,7 +21,5 @@ func NewDeleteSnapshotDialog(application *tview.Application, snapshot *data.Snap
 		" 💥 Destroy Snapshot ",
 		fmt.Sprintf("Destroy '%s'?", snapshot.Snapshot.Name),
 		buildConfirmDialogOptions(DeleteSnapshotDialogDeleteSnapshotActionId, "Destroy", true, DialogSeverityDanger),
-		50,
-		6,
 	)
 }

--- a/internal/ui/dialog/file_action_dialog.go
+++ b/internal/ui/dialog/file_action_dialog.go
@@ -30,8 +30,6 @@ func NewFileActionDialog(application *tview.Application, file *data.FileBrowserE
 		localization.LocalizationSelectActionDialogTitle,
 		fmt.Sprintf("What do you want to do with '%s'?", file.Name),
 		dialogOptions,
-		50,
-		15,
 	)
 }
 

--- a/internal/ui/dialog/file_diff_dialog.go
+++ b/internal/ui/dialog/file_diff_dialog.go
@@ -82,8 +82,12 @@ func (d *FileDiffDialog) createLayout() {
 	dialogContent.AddItem(closeTextView, 1, 0, false)
 	dialogContent.SetBorderPadding(0, 0, 1, 1)
 
-	width := 80
-	height := 20
+	width, height := CalculateDialogSize(DialogSizeConstraints{
+		Title:             dialogTitle,
+		ExtraContentWidth: 74,
+		StaticHeight:      18, // Sane content height for scrollable diff text
+	})
+
 	dialog := createModal(dialogTitle, dialogContent, width, height)
 	dialog.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {

--- a/internal/ui/dialog/file_diff_dialog_test.go
+++ b/internal/ui/dialog/file_diff_dialog_test.go
@@ -1,0 +1,31 @@
+package dialog
+
+import (
+	"testing"
+	"zfs-file-history/internal/data"
+	"zfs-file-history/internal/zfs"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFileDiffDialog(t *testing.T) {
+	app := tview.NewApplication()
+	file := &data.FileBrowserEntry{
+		RealFile: &data.RealFile{Path: "/pool/ds1/file.txt"},
+	}
+	snapshot := &data.SnapshotBrowserEntry{
+		Snapshot: &zfs.Snapshot{
+			Name: "snap-1",
+			ParentDataset: &zfs.Dataset{
+				Path:          "/pool/ds1",
+				HiddenZfsPath: "/pool/ds1/.zfs",
+			},
+		},
+	}
+
+	d := NewFileDiffDialog(app, file, snapshot)
+	assert.Equal(t, "FileDiffDialog", d.GetName())
+	assert.NotNil(t, d.GetLayout())
+	assert.NotNil(t, d.GetActionChannel())
+}

--- a/internal/ui/dialog/help_dialog.go
+++ b/internal/ui/dialog/help_dialog.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"fmt"
+	"unicode/utf8"
 	"zfs-file-history/internal/ui/theme"
 
 	"github.com/gdamore/tcell/v2"
@@ -49,7 +50,33 @@ func (p *HelpPage) createLayout() {
 		setHelpTableRow(helpTable, row, entry)
 	}
 
-	p.layout = createModal(" ℹ️ Help ", helpTable, 60, 14)
+	maxKeyWidth := 0
+	maxValueWidth := 0
+	for _, entry := range helpTableEntries {
+		if entry == emptyEntry {
+			continue
+		}
+		kw := utf8.RuneCountInString(entry.Key) + 1 // key + colon
+		if kw > maxKeyWidth {
+			maxKeyWidth = kw
+		}
+		vw := utf8.RuneCountInString(entry.Value)
+		if vw > maxValueWidth {
+			maxValueWidth = vw
+		}
+	}
+
+	// Total width is the sum of both columns plus the 1-character table column gap
+	maxHelpWidth := maxKeyWidth + 1 + maxValueWidth
+
+	title := " ℹ️ Help "
+	width, height := CalculateDialogSize(DialogSizeConstraints{
+		Title:             title,
+		ExtraContentWidth: maxHelpWidth,
+		StaticHeight:      len(helpTableEntries),
+	})
+
+	p.layout = createModal(title, helpTable, width, height)
 }
 
 func setHelpTableRow(helpTable *tview.Table, row int, entry *TableEntry) {

--- a/internal/ui/dialog/help_dialog_test.go
+++ b/internal/ui/dialog/help_dialog_test.go
@@ -46,3 +46,8 @@ func TestSetHelpTableRow_EmptyEntry_LeavesKeyEmpty(t *testing.T) {
 	assert.Equal(t, tcell.ColorWhite, keyFg)
 	assert.Equal(t, "", valueCell.Text)
 }
+
+func TestNewHelpPage(t *testing.T) {
+	p := NewHelpPage()
+	assert.NotNil(t, p.GetLayout())
+}

--- a/internal/ui/dialog/restore_file_dialog.go
+++ b/internal/ui/dialog/restore_file_dialog.go
@@ -24,8 +24,6 @@ func NewRestoreFileDialog(application *tview.Application, file *data.FileBrowser
 		" ♻️ Restore File ",
 		fmt.Sprintf("Restore '%s'?", file.Name),
 		buildRestoreDialogOptions(file),
-		50,
-		6,
 	)
 }
 

--- a/internal/ui/dialog/restore_file_progress_dialog.go
+++ b/internal/ui/dialog/restore_file_progress_dialog.go
@@ -26,6 +26,8 @@ type RestoreFileProgressDialog struct {
 	layout              *tview.Flex
 	descriptionTextView *tview.TextView
 	actionsHelpTextView *tview.TextView
+	actionPages         *tview.Pages
+	closeTable          *tview.Table
 
 	progress      *tvxwidgets.PercentageModeGauge
 	progressValue int
@@ -63,8 +65,12 @@ func (d *RestoreFileProgressDialog) createLayout() {
 			if !d.isRunning {
 				break
 			}
-			spinner.Pulse()
-			d.application.Draw()
+			d.application.QueueUpdateDraw(func() {
+				if !d.isRunning {
+					return
+				}
+				spinner.Pulse()
+			})
 		}
 	}
 	go updateSpinner()
@@ -76,6 +82,22 @@ func (d *RestoreFileProgressDialog) createLayout() {
 	abortTextView := uiutil.CreateAttentionTextView("Press 'q' to abort")
 	d.actionsHelpTextView = abortTextView
 
+	dialogOptions := []*DialogOption{
+		{
+			Id:   DialogCloseActionId,
+			Name: "Close",
+		},
+	}
+	closeTable := createOptionTable(d.application, dialogOptions, func(option *DialogOption) {
+		d.Close()
+	})
+	d.closeTable = closeTable
+
+	actionPages := tview.NewPages().
+		AddPage("running", abortTextView, true, true).
+		AddPage("finished", closeTable, true, false)
+	d.actionPages = actionPages
+
 	progress := tvxwidgets.NewPercentageModeGauge()
 	progressTitle := theme.CreateTitleText("Progress")
 	progress.SetTitle(progressTitle)
@@ -85,12 +107,16 @@ func (d *RestoreFileProgressDialog) createLayout() {
 	progressLayout := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(descriptionLayout, 0, 1, false).
 		AddItem(progress, 3, 0, false).
-		AddItem(abortTextView, 1, 0, false)
+		AddItem(actionPages, 1, 0, false)
 	progressLayout.SetBorderPadding(0, 0, 1, 1)
 
 	dialog := createModal(dialogTitle, progressLayout, 60, 10)
 	dialog.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
+			d.Close()
+			return nil
+		}
+		if !d.isRunning && event.Key() == tcell.KeyEnter {
 			d.Close()
 			return nil
 		}
@@ -131,7 +157,6 @@ func (d *RestoreFileProgressDialog) runAction(recursive bool) {
 			for i := 0; i < 2; i++ {
 				err := snapshot.RestoreRecursive(srcFilePath)
 				d.handleError(err)
-				d.application.Draw()
 				if err != nil {
 					return
 				}
@@ -139,14 +164,12 @@ func (d *RestoreFileProgressDialog) runAction(recursive bool) {
 		} else {
 			err := snapshot.Restore(srcFilePath)
 			d.handleError(err)
-			d.application.Draw()
 			if err != nil {
 				return
 			}
 		}
 
 		d.handleDone()
-		d.application.Draw()
 	}()
 
 	d.progressValue = 0
@@ -159,9 +182,13 @@ func (d *RestoreFileProgressDialog) runAction(recursive bool) {
 			if !d.isRunning {
 				break
 			}
-			d.progressValue = int(math.Min(float64(d.progress.GetMaxValue()), float64(d.progressValue)))
-			d.progress.SetValue(d.progressValue)
-			d.application.Draw()
+			d.application.QueueUpdateDraw(func() {
+				if !d.isRunning {
+					return
+				}
+				d.progressValue = int(math.Min(float64(d.progress.GetMaxValue()), float64(d.progressValue)))
+				d.progress.SetValue(d.progressValue)
+			})
 		}
 	}
 	go progressUpdate()
@@ -171,18 +198,24 @@ func (d *RestoreFileProgressDialog) handleError(err error) {
 	if err != nil {
 		logging.Error("Error during restore: %s", err.Error())
 		d.isRunning = false
-		d.descriptionTextView.SetText(err.Error()).SetTextColor(tcell.ColorRed)
-		d.progress.SetTitle(theme.CreateTitleText("Failed!"))
-		d.progress.SetTitleColor(tcell.ColorRed)
-		d.actionsHelpTextView.SetText("Press 'esc' to close")
+		d.application.QueueUpdateDraw(func() {
+			d.descriptionTextView.SetText(err.Error()).SetTextColor(tcell.ColorRed)
+			d.progress.SetTitle(theme.CreateTitleText("Failed!"))
+			d.progress.SetTitleColor(tcell.ColorRed)
+			d.actionPages.ShowPage("finished")
+			d.application.SetFocus(d.closeTable)
+		})
 	}
 }
 
 func (d *RestoreFileProgressDialog) handleDone() {
 	d.isRunning = false
-	finishedValue := d.progress.GetMaxValue()
-	d.progress.SetValue(finishedValue)
-	d.progress.SetTitle(theme.CreateTitleText("Done!"))
-	d.progress.SetTitleColor(tcell.ColorGreen)
-	d.actionsHelpTextView.SetText(uiutil.CreateAttentionText("Press 'esc' to close"))
+	d.application.QueueUpdateDraw(func() {
+		finishedValue := d.progress.GetMaxValue()
+		d.progress.SetValue(finishedValue)
+		d.progress.SetTitle(theme.CreateTitleText("Done!"))
+		d.progress.SetTitleColor(tcell.ColorGreen)
+		d.actionPages.ShowPage("finished")
+		d.application.SetFocus(d.closeTable)
+	})
 }

--- a/internal/ui/dialog/restore_file_progress_dialog.go
+++ b/internal/ui/dialog/restore_file_progress_dialog.go
@@ -110,7 +110,13 @@ func (d *RestoreFileProgressDialog) createLayout() {
 		AddItem(actionPages, 1, 0, false)
 	progressLayout.SetBorderPadding(0, 0, 1, 1)
 
-	dialog := createModal(dialogTitle, progressLayout, 60, 10)
+	width, height := CalculateDialogSize(DialogSizeConstraints{
+		Title:        dialogTitle,
+		Description:  text,
+		StaticHeight: 4, // 3 for progress bar, 1 for actionPages
+	})
+
+	dialog := createModal(dialogTitle, progressLayout, width, height)
 	dialog.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
 			d.Close()

--- a/internal/ui/dialog/restore_file_progress_dialog_test.go
+++ b/internal/ui/dialog/restore_file_progress_dialog_test.go
@@ -1,0 +1,41 @@
+package dialog
+
+import (
+	"testing"
+	"time"
+	"zfs-file-history/internal/data"
+	"zfs-file-history/internal/zfs"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRestoreFileProgressDialog(t *testing.T) {
+	app := tview.NewApplication()
+	file := &data.FileBrowserEntry{
+		Name: "test.txt",
+		SnapshotFiles: []*data.SnapshotFile{
+			{
+				Path: "/pool/ds1/.zfs/snapshot/snap1/test.txt",
+				Snapshot: &zfs.Snapshot{
+					Name: "snap1",
+					ParentDataset: &zfs.Dataset{
+						Path:          "/pool/ds1",
+						HiddenZfsPath: "/pool/ds1/.zfs",
+					},
+				},
+			},
+		},
+	}
+
+	d := NewRestoreFileProgressDialog(app, file, false)
+
+	assert.Equal(t, string(RestoreFileProgress), d.GetName())
+	assert.NotNil(t, d.GetLayout())
+	assert.NotNil(t, d.GetActionChannel())
+
+	// Wait briefly to allow background goroutine and handleError to execute
+	time.Sleep(100 * time.Millisecond)
+
+	d.Close()
+}

--- a/internal/ui/dialog/selection_dialog.go
+++ b/internal/ui/dialog/selection_dialog.go
@@ -1,6 +1,13 @@
 package dialog
 
-import "github.com/rivo/tview"
+import (
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/rivo/tview"
+	"golang.org/x/term"
+)
 
 type SelectionDialog struct {
 	application   *tview.Application
@@ -18,8 +25,6 @@ func NewSelectionDialog(
 	title string,
 	description string,
 	options []*DialogOption,
-	width int,
-	height int,
 ) *SelectionDialog {
 	d := &SelectionDialog{
 		application:   application,
@@ -29,19 +34,75 @@ func NewSelectionDialog(
 		options:       options,
 		actionChannel: make(chan DialogActionId),
 	}
-	d.createLayout(width, height)
+	d.createLayout()
 	return d
 }
 
-func (d *SelectionDialog) createLayout(width int, height int) {
-	textDescriptionView := tview.NewTextView().SetText(d.description)
+func (d *SelectionDialog) createLayout() {
+	termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || termWidth <= 0 || termHeight <= 0 {
+		termWidth = 80
+		termHeight = 24
+	}
+
+	minWidth := 40
+	maxWidth := 80
+	if maxWidth > termWidth-4 {
+		maxWidth = termWidth - 4
+	}
+	if minWidth > maxWidth {
+		minWidth = maxWidth
+	}
+	if minWidth < 10 {
+		minWidth = 10
+	}
+
+	maxContentWidth := utf8.RuneCountInString(d.title)
+	if l := utf8.RuneCountInString(d.description); l > maxContentWidth {
+		maxContentWidth = l
+	}
+	for _, opt := range d.options {
+		if l := utf8.RuneCountInString(opt.Name); l > maxContentWidth {
+			maxContentWidth = l
+		}
+	}
+
+	dialogWidth := maxContentWidth + 6
+	if dialogWidth < minWidth {
+		dialogWidth = minWidth
+	}
+	if dialogWidth > maxWidth {
+		dialogWidth = maxWidth
+	}
+
+	textLineWidth := dialogWidth - 6
+	if textLineWidth < 5 {
+		textLineWidth = 5
+	}
+	descHeight := calculateWrappedHeight(d.description, textLineWidth)
+
+	dialogHeight := 2 + descHeight + 1 + len(d.options)
+	maxHeight := termHeight - 2
+	if maxHeight < 5 {
+		maxHeight = 5
+	}
+	if dialogHeight > maxHeight {
+		dialogHeight = maxHeight
+	}
+
+	textDescriptionView := tview.NewTextView().
+		SetText(d.description).
+		SetWrap(true).
+		SetWordWrap(true)
+
 	optionTable := createOptionTable(d.application, d.options, d.selectAction)
 
 	dialogContent := tview.NewFlex().SetDirection(tview.FlexRow)
-	dialogContent.AddItem(textDescriptionView, 0, 1, false)
-	dialogContent.AddItem(optionTable, 0, 1, true)
+	dialogContent.AddItem(textDescriptionView, descHeight, 0, false)
+	dialogContent.AddItem(nil, 1, 0, false) // 1 line spacer/padding
+	dialogContent.AddItem(optionTable, len(d.options), 0, true)
 
-	dialog := createModal(d.title, dialogContent, width, height)
+	dialog := createModal(d.title, dialogContent, dialogWidth, dialogHeight)
 	dialog.SetInputCapture(createOptionDialogInputCapture(optionTable, d.options, d.selectAction, d.Close))
 	d.layout = dialog
 }
@@ -64,4 +125,18 @@ func (d *SelectionDialog) Close() {
 
 func (d *SelectionDialog) selectAction(option *DialogOption) {
 	emitDialogActions(d.actionChannel, DialogCloseActionId, option.Id)
+}
+
+func calculateWrappedHeight(text string, maxLineWidth int) int {
+	lines := strings.Split(text, "\n")
+	height := 0
+	for _, line := range lines {
+		runes := utf8.RuneCountInString(line)
+		if runes == 0 {
+			height += 1
+			continue
+		}
+		height += (runes + maxLineWidth - 1) / maxLineWidth
+	}
+	return height
 }

--- a/internal/ui/dialog/selection_dialog.go
+++ b/internal/ui/dialog/selection_dialog.go
@@ -38,8 +38,13 @@ func NewSelectionDialog(
 func (d *SelectionDialog) createLayout() {
 	maxOptWidth := 0
 	for _, opt := range d.options {
-		if l := utf8.RuneCountInString(opt.Name); l > maxOptWidth {
-			maxOptWidth = l
+		prefixLen := 2 // E.g. "1."
+		if opt.Id == DialogCloseActionId {
+			prefixLen = 4 // E.g. "Esc."
+		}
+		optWidth := prefixLen + 1 + utf8.RuneCountInString(opt.Name)
+		if optWidth > maxOptWidth {
+			maxOptWidth = optWidth
 		}
 	}
 

--- a/internal/ui/dialog/selection_dialog.go
+++ b/internal/ui/dialog/selection_dialog.go
@@ -81,7 +81,21 @@ func (d *SelectionDialog) createLayout() {
 	}
 	descHeight := calculateWrappedHeight(d.description, textLineWidth)
 
-	dialogHeight := 2 + descHeight + 1 + len(d.options)
+	actualTableRows := len(d.options)
+	if len(d.options) > 1 {
+		hasClose := false
+		for _, opt := range d.options {
+			if opt.Id == DialogCloseActionId {
+				hasClose = true
+				break
+			}
+		}
+		if hasClose {
+			actualTableRows++
+		}
+	}
+
+	dialogHeight := 2 + descHeight + 1 + actualTableRows
 	maxHeight := termHeight - 2
 	if maxHeight < 5 {
 		maxHeight = 5
@@ -99,8 +113,8 @@ func (d *SelectionDialog) createLayout() {
 
 	dialogContent := tview.NewFlex().SetDirection(tview.FlexRow)
 	dialogContent.AddItem(textDescriptionView, descHeight, 0, false)
-	dialogContent.AddItem(nil, 1, 0, false) // 1 line spacer/padding
-	dialogContent.AddItem(optionTable, len(d.options), 0, true)
+	dialogContent.AddItem(tview.NewBox(), 1, 0, false) // 1 line spacer/padding
+	dialogContent.AddItem(optionTable, actualTableRows, 0, true)
 
 	dialog := createModal(d.title, dialogContent, dialogWidth, dialogHeight)
 	dialog.SetInputCapture(createOptionDialogInputCapture(optionTable, d.options, d.selectAction, d.Close))

--- a/internal/ui/dialog/selection_dialog.go
+++ b/internal/ui/dialog/selection_dialog.go
@@ -1,12 +1,9 @@
 package dialog
 
 import (
-	"os"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/rivo/tview"
-	"golang.org/x/term"
 )
 
 type SelectionDialog struct {
@@ -39,47 +36,12 @@ func NewSelectionDialog(
 }
 
 func (d *SelectionDialog) createLayout() {
-	termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || termWidth <= 0 || termHeight <= 0 {
-		termWidth = 80
-		termHeight = 24
-	}
-
-	minWidth := 40
-	maxWidth := 80
-	if maxWidth > termWidth-4 {
-		maxWidth = termWidth - 4
-	}
-	if minWidth > maxWidth {
-		minWidth = maxWidth
-	}
-	if minWidth < 10 {
-		minWidth = 10
-	}
-
-	maxContentWidth := utf8.RuneCountInString(d.title)
-	if l := utf8.RuneCountInString(d.description); l > maxContentWidth {
-		maxContentWidth = l
-	}
+	maxOptWidth := 0
 	for _, opt := range d.options {
-		if l := utf8.RuneCountInString(opt.Name); l > maxContentWidth {
-			maxContentWidth = l
+		if l := utf8.RuneCountInString(opt.Name); l > maxOptWidth {
+			maxOptWidth = l
 		}
 	}
-
-	dialogWidth := maxContentWidth + 6
-	if dialogWidth < minWidth {
-		dialogWidth = minWidth
-	}
-	if dialogWidth > maxWidth {
-		dialogWidth = maxWidth
-	}
-
-	textLineWidth := dialogWidth - 6
-	if textLineWidth < 5 {
-		textLineWidth = 5
-	}
-	descHeight := calculateWrappedHeight(d.description, textLineWidth)
 
 	actualTableRows := len(d.options)
 	if len(d.options) > 1 {
@@ -95,14 +57,18 @@ func (d *SelectionDialog) createLayout() {
 		}
 	}
 
-	dialogHeight := 2 + descHeight + 1 + actualTableRows
-	maxHeight := termHeight - 2
-	if maxHeight < 5 {
-		maxHeight = 5
+	dialogWidth, dialogHeight := CalculateDialogSize(DialogSizeConstraints{
+		Title:             d.title,
+		Description:       d.description,
+		ExtraContentWidth: maxOptWidth,
+		StaticHeight:      1 + actualTableRows, // 1 line for the spacer box
+	})
+
+	textLineWidth := dialogWidth - 6
+	if textLineWidth < 5 {
+		textLineWidth = 5
 	}
-	if dialogHeight > maxHeight {
-		dialogHeight = maxHeight
-	}
+	descHeight := calculateWrappedHeight(d.description, textLineWidth)
 
 	textDescriptionView := tview.NewTextView().
 		SetText(d.description).
@@ -139,18 +105,4 @@ func (d *SelectionDialog) Close() {
 
 func (d *SelectionDialog) selectAction(option *DialogOption) {
 	emitDialogActions(d.actionChannel, DialogCloseActionId, option.Id)
-}
-
-func calculateWrappedHeight(text string, maxLineWidth int) int {
-	lines := strings.Split(text, "\n")
-	height := 0
-	for _, line := range lines {
-		runes := utf8.RuneCountInString(line)
-		if runes == 0 {
-			height += 1
-			continue
-		}
-		height += (runes + maxLineWidth - 1) / maxLineWidth
-	}
-	return height
 }

--- a/internal/ui/dialog/selection_dialog_test.go
+++ b/internal/ui/dialog/selection_dialog_test.go
@@ -1,0 +1,179 @@
+package dialog
+
+import (
+	"testing"
+	"zfs-file-history/internal/data"
+	"zfs-file-history/internal/data/diff_state"
+	"zfs-file-history/internal/ui/localization"
+	"zfs-file-history/internal/zfs"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSelectionDialog(t *testing.T) {
+	app := tview.NewApplication()
+	options := []*DialogOption{
+		{Id: DialogActionId(1), Name: "Option 1"},
+		{Id: DialogCloseActionId, Name: "Cancel"},
+	}
+	d := NewSelectionDialog(app, "test-dialog", "Title", "Description Text", options)
+
+	assert.Equal(t, "test-dialog", d.GetName())
+	assert.NotNil(t, d.GetLayout())
+	assert.NotNil(t, d.GetActionChannel())
+}
+
+func TestSelectionDialog_NumericJumpShortcuts(t *testing.T) {
+	app := tview.NewApplication()
+	options := []*DialogOption{
+		{Id: DialogActionId(1), Name: "Option A"},
+		{Id: DialogActionId(2), Name: "Option B"},
+		{Id: DialogCloseActionId, Name: "Close"},
+	}
+
+	onSelect := func(opt *DialogOption) {}
+	onClose := func() {}
+
+	optionTable := createOptionTable(app, options, onSelect)
+	capture := createOptionDialogInputCapture(optionTable, options, onSelect, onClose)
+
+	// Initially, row 0 is selected
+	row, _ := optionTable.GetSelection()
+	assert.Equal(t, 0, row)
+
+	// Press '2' to jump to Option B (row 1 in the table, since row 2 is spacer, row 3 is Close)
+	evt2 := tcell.NewEventKey(tcell.KeyRune, '2', tcell.ModNone)
+	res := capture(evt2)
+	assert.Nil(t, res) // Consumed
+
+	row, _ = optionTable.GetSelection()
+	assert.Equal(t, 1, row) // Row 1 is Option B
+
+	// Press '1' to jump to Option A
+	evt1 := tcell.NewEventKey(tcell.KeyRune, '1', tcell.ModNone)
+	res = capture(evt1)
+	assert.Nil(t, res) // Consumed
+
+	row, _ = optionTable.GetSelection()
+	assert.Equal(t, 0, row)
+
+	// Press '3' (out of range, since we only have 2 numbered options)
+	evt3 := tcell.NewEventKey(tcell.KeyRune, '3', tcell.ModNone)
+	res = capture(evt3)
+	assert.Nil(t, res) // Consumed, but should not change selection
+
+	row, _ = optionTable.GetSelection()
+	assert.Equal(t, 0, row) // Remains 0
+}
+
+func TestNewDeleteFileDialog(t *testing.T) {
+	app := tview.NewApplication()
+	file := &data.FileBrowserEntry{
+		Name:     "to_delete.txt",
+		RealFile: &data.RealFile{Name: "to_delete.txt"},
+	}
+
+	d := NewDeleteFileDialog(app, file)
+	assert.Equal(t, "DeleteFileDialog", d.GetName())
+}
+
+func TestNewDeleteSnapshotDialog(t *testing.T) {
+	app := tview.NewApplication()
+	snapshot := &data.SnapshotBrowserEntry{
+		Snapshot: &zfs.Snapshot{
+			Name: "snapshot-1",
+			ParentDataset: &zfs.Dataset{
+				Path:          "/pool/ds1",
+				HiddenZfsPath: "/pool/ds1/.zfs",
+			},
+		},
+	}
+
+	d := NewDeleteSnapshotDialog(app, snapshot)
+	assert.Equal(t, "DeleteSnapshotDialog", d.GetName())
+}
+
+func TestNewFileActionDialog(t *testing.T) {
+	app := tview.NewApplication()
+	file := &data.FileBrowserEntry{
+		Name:      "test.txt",
+		RealFile:  &data.RealFile{Name: "test.txt", Path: "/pool/ds1/test.txt"},
+		Type:      data.File,
+		DiffState: diff_state.Modified,
+		SnapshotFiles: []*data.SnapshotFile{
+			{
+				Path: "/pool/ds1/.zfs/snapshot/snap-file/test.txt",
+				Snapshot: &zfs.Snapshot{
+					Name: "snap-file",
+					ParentDataset: &zfs.Dataset{
+						Path:          "/pool/ds1",
+						HiddenZfsPath: "/pool/ds1/.zfs",
+					},
+				},
+			},
+		},
+	}
+
+	d := NewFileActionDialog(app, file)
+	assert.Equal(t, "ActionDialog", d.GetName())
+}
+
+func TestNewSnapshotActionDialog(t *testing.T) {
+	app := tview.NewApplication()
+	snapshot := &data.SnapshotBrowserEntry{
+		Snapshot: &zfs.Snapshot{
+			Name: "snapshot-2",
+			ParentDataset: &zfs.Dataset{
+				Path:          "/pool/ds1",
+				HiddenZfsPath: "/pool/ds1/.zfs",
+			},
+		},
+	}
+
+	d := NewSnapshotActionDialog(app, snapshot)
+	assert.Equal(t, "SnapshotActionDialog", d.GetName())
+}
+
+func TestNewMultiSnapshotActionDialog(t *testing.T) {
+	app := tview.NewApplication()
+	snapshots := []*data.SnapshotBrowserEntry{
+		{
+			Snapshot: &zfs.Snapshot{
+				Name: "snapshot-3",
+				ParentDataset: &zfs.Dataset{
+					Path:          "/pool/ds1",
+					HiddenZfsPath: "/pool/ds1/.zfs",
+				},
+			},
+		},
+		{
+			Snapshot: &zfs.Snapshot{
+				Name: "snapshot-4",
+				ParentDataset: &zfs.Dataset{
+					Path:          "/pool/ds1",
+					HiddenZfsPath: "/pool/ds1/.zfs",
+				},
+			},
+		},
+	}
+
+	d := NewMultiSnapshotActionDialog(app, snapshots)
+	assert.Equal(t, "MultiSnapshotActionDialog", d.GetName())
+}
+
+func TestNewRestoreFileDialog(t *testing.T) {
+	app := tview.NewApplication()
+	file := &data.FileBrowserEntry{
+		Name: "test.txt",
+		Type: data.File,
+	}
+
+	d := NewRestoreFileDialog(app, file)
+	assert.Equal(t, "RestoreFileDialog", d.GetName())
+
+	opts := buildRestoreDialogOptions(file)
+	assert.NotEmpty(t, opts)
+	assert.Equal(t, localization.LocalizationCommonClose, opts[len(opts)-1].Name)
+}

--- a/internal/ui/dialog/sizing_test.go
+++ b/internal/ui/dialog/sizing_test.go
@@ -1,0 +1,105 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateWrappedHeight(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         string
+		maxLineWidth int
+		expected     int
+	}{
+		{
+			name:         "empty text",
+			text:         "",
+			maxLineWidth: 10,
+			expected:     1,
+		},
+		{
+			name:         "single line fitting fully",
+			text:         "hello",
+			maxLineWidth: 10,
+			expected:     1,
+		},
+		{
+			name:         "single line wrapping once",
+			text:         "hello world", // 11 runes
+			maxLineWidth: 10,
+			expected:     2,
+		},
+		{
+			name:         "single line wrapping twice",
+			text:         "hello world wide web", // 20 runes
+			maxLineWidth: 8,
+			expected:     3,
+		},
+		{
+			name:         "multiple lines with empty lines",
+			text:         "line1\n\nline2",
+			maxLineWidth: 10,
+			expected:     3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			height := calculateWrappedHeight(tt.text, tt.maxLineWidth)
+			assert.Equal(t, tt.expected, height)
+		})
+	}
+}
+
+func TestCalculateDialogSize(t *testing.T) {
+	tests := []struct {
+		name        string
+		constraints DialogSizeConstraints
+		minWidth    int
+		maxWidth    int
+	}{
+		{
+			name: "short title and description",
+			constraints: DialogSizeConstraints{
+				Title:             "Short Title",
+				Description:       "Short Description",
+				ExtraContentWidth: 10,
+				StaticHeight:      3,
+			},
+			minWidth: 40,
+			maxWidth: 80,
+		},
+		{
+			name: "long description wrapping",
+			constraints: DialogSizeConstraints{
+				Title:             "Short Title",
+				Description:       "This is a very long description that should wrap multiple times on a typical screen layout size constraint.",
+				ExtraContentWidth: 20,
+				StaticHeight:      5,
+			},
+			minWidth: 40,
+			maxWidth: 80,
+		},
+		{
+			name: "large extra content width",
+			constraints: DialogSizeConstraints{
+				Title:             "Title",
+				Description:       "",
+				ExtraContentWidth: 90,
+				StaticHeight:      4,
+			},
+			minWidth: 40,
+			maxWidth: 80,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, h := CalculateDialogSize(tt.constraints)
+			assert.GreaterOrEqual(t, w, tt.minWidth)
+			assert.GreaterOrEqual(t, h, 2+tt.constraints.StaticHeight)
+		})
+	}
+}

--- a/internal/ui/dialog/snapshot_action_dialog.go
+++ b/internal/ui/dialog/snapshot_action_dialog.go
@@ -45,7 +45,5 @@ func NewSnapshotActionDialog(application *tview.Application, snapshot *data.Snap
 		localization.LocalizationSelectActionDialogTitle,
 		fmt.Sprintf("What do you want to do with '%s'?", snapshot.Snapshot.Name),
 		dialogOptions,
-		50,
-		10,
 	)
 }

--- a/internal/ui/dialog/snapshot_multi_action_dialog.go
+++ b/internal/ui/dialog/snapshot_multi_action_dialog.go
@@ -50,7 +50,5 @@ func NewMultiSnapshotActionDialog(application *tview.Application, snapshots []*d
 		localization.LocalizationSelectActionDialogTitle,
 		fmt.Sprintf("What do you want to do with '%v'?", snapshotNames),
 		dialogOptions,
-		50,
-		10,
 	)
 }

--- a/internal/ui/dialog/util.go
+++ b/internal/ui/dialog/util.go
@@ -1,13 +1,17 @@
 package dialog
 
 import (
+	"os"
 	"slices"
+	"strings"
 	"time"
+	"unicode/utf8"
 	"zfs-file-history/internal/ui/localization"
 	uiutil "zfs-file-history/internal/ui/util"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"golang.org/x/term"
 )
 
 type DialogActionId int
@@ -243,4 +247,86 @@ func ShowDialogOnPages(
 	if onUpdate != nil {
 		onUpdate()
 	}
+}
+
+// DialogSizeConstraints holds the input parameters for calculating a dialog's size.
+type DialogSizeConstraints struct {
+	Title             string
+	Description       string
+	ExtraContentWidth int
+	StaticHeight      int
+}
+
+// CalculateDialogSize computes a sane width and height for a dialog based on terminal bounds and content needs.
+func CalculateDialogSize(constraints DialogSizeConstraints) (width int, height int) {
+	termWidth, termHeight, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || termWidth <= 0 || termHeight <= 0 {
+		termWidth = 80
+		termHeight = 24
+	}
+
+	minWidth := 40
+	maxWidth := 80
+	if maxWidth > termWidth-4 {
+		maxWidth = termWidth - 4
+	}
+	if minWidth > maxWidth {
+		minWidth = maxWidth
+	}
+	if minWidth < 10 {
+		minWidth = 10
+	}
+
+	maxContentWidth := utf8.RuneCountInString(constraints.Title)
+	if constraints.Description != "" {
+		if l := utf8.RuneCountInString(constraints.Description); l > maxContentWidth {
+			maxContentWidth = l
+		}
+	}
+	if constraints.ExtraContentWidth > maxContentWidth {
+		maxContentWidth = constraints.ExtraContentWidth
+	}
+
+	dialogWidth := maxContentWidth + 6
+	if dialogWidth < minWidth {
+		dialogWidth = minWidth
+	}
+	if dialogWidth > maxWidth {
+		dialogWidth = maxWidth
+	}
+
+	textLineWidth := dialogWidth - 6
+	if textLineWidth < 5 {
+		textLineWidth = 5
+	}
+
+	descHeight := 0
+	if constraints.Description != "" {
+		descHeight = calculateWrappedHeight(constraints.Description, textLineWidth)
+	}
+
+	dialogHeight := 2 + descHeight + constraints.StaticHeight
+	maxHeight := termHeight - 2
+	if maxHeight < 5 {
+		maxHeight = 5
+	}
+	if dialogHeight > maxHeight {
+		dialogHeight = maxHeight
+	}
+
+	return dialogWidth, dialogHeight
+}
+
+func calculateWrappedHeight(text string, maxLineWidth int) int {
+	lines := strings.Split(text, "\n")
+	height := 0
+	for _, line := range lines {
+		runes := utf8.RuneCountInString(line)
+		if runes == 0 {
+			height += 1
+			continue
+		}
+		height += (runes + maxLineWidth - 1) / maxLineWidth
+	}
+	return height
 }

--- a/internal/ui/dialog/util.go
+++ b/internal/ui/dialog/util.go
@@ -85,7 +85,10 @@ func createOptionTable(application *tview.Application, options []*DialogOption, 
 	optionTable.SetSelectable(true, false)
 	optionTable.Select(0, 0)
 
-	for row, option := range options {
+	tableRow := 0
+	hasMultipleOptions := len(options) > 1
+
+	for _, option := range options {
 		var textColor tcell.Color
 		switch option.Severity {
 		case DialogSeverityNeutral:
@@ -97,13 +100,33 @@ func createOptionTable(application *tview.Application, options []*DialogOption, 
 		case DialogSeverityDanger:
 			textColor = tcell.ColorRed
 		}
-		optionTable.SetCell(row, 0,
-			tview.NewTableCell(option.Name).
-				SetTextColor(textColor).
-				SetAlign(tview.AlignLeft).
-				SetExpansion(1),
-		)
+
+		if option.Id == DialogCloseActionId && hasMultipleOptions {
+			optionTable.SetCell(tableRow, 0,
+				tview.NewTableCell("").
+					SetSelectable(false),
+			)
+			tableRow++
+		}
+
+		cell := tview.NewTableCell(option.Name).
+			SetTextColor(textColor).
+			SetAlign(tview.AlignLeft).
+			SetExpansion(1)
+		cell.SetReference(option)
+
+		optionTable.SetCell(tableRow, 0, cell)
+		tableRow++
 	}
+
+	optionTable.SetSelectedFunc(func(row, column int) {
+		cell := optionTable.GetCell(row, column)
+		if cell != nil && cell.GetReference() != nil {
+			if option, ok := cell.GetReference().(*DialogOption); ok {
+				onSelect(option)
+			}
+		}
+	})
 
 	return optionTable
 }
@@ -121,7 +144,12 @@ func createOptionDialogInputCapture(
 		}
 		if event.Key() == tcell.KeyEnter {
 			row, _ := optionTable.GetSelection()
-			onSelect(options[row])
+			cell := optionTable.GetCell(row, 0)
+			if cell != nil && cell.GetReference() != nil {
+				if option, ok := cell.GetReference().(*DialogOption); ok {
+					onSelect(option)
+				}
+			}
 			return nil
 		}
 		return event

--- a/internal/ui/dialog/util.go
+++ b/internal/ui/dialog/util.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"fmt"
 	"os"
 	"slices"
 	"strings"
@@ -91,6 +92,7 @@ func createOptionTable(application *tview.Application, options []*DialogOption, 
 
 	tableRow := 0
 	hasMultipleOptions := len(options) > 1
+	nonCloseIndex := 0
 
 	for _, option := range options {
 		var textColor tcell.Color
@@ -106,25 +108,39 @@ func createOptionTable(application *tview.Application, options []*DialogOption, 
 		}
 
 		if option.Id == DialogCloseActionId && hasMultipleOptions {
-			optionTable.SetCell(tableRow, 0,
-				tview.NewTableCell("").
-					SetSelectable(false),
-			)
+			optionTable.SetCell(tableRow, 0, tview.NewTableCell("").SetSelectable(false))
+			optionTable.SetCell(tableRow, 1, tview.NewTableCell("").SetSelectable(false))
 			tableRow++
 		}
 
-		cell := tview.NewTableCell(option.Name).
+		prefixText := ""
+		if option.Id == DialogCloseActionId {
+			prefixText = "Esc."
+		} else {
+			nonCloseIndex++
+			prefixText = fmt.Sprintf("%d.", nonCloseIndex)
+		}
+
+		prefixCell := tview.NewTableCell(prefixText).
+			SetTextColor(tcell.ColorGray).
+			SetAlign(tview.AlignRight)
+		prefixCell.SetSelectedStyle(tcell.StyleDefault.
+			Foreground(tcell.ColorGray).
+			Background(tview.Styles.PrimitiveBackgroundColor))
+
+		nameCell := tview.NewTableCell(option.Name).
 			SetTextColor(textColor).
 			SetAlign(tview.AlignLeft).
 			SetExpansion(1)
-		cell.SetReference(option)
+		nameCell.SetReference(option)
 
-		optionTable.SetCell(tableRow, 0, cell)
+		optionTable.SetCell(tableRow, 0, prefixCell)
+		optionTable.SetCell(tableRow, 1, nameCell)
 		tableRow++
 	}
 
 	optionTable.SetSelectedFunc(func(row, column int) {
-		cell := optionTable.GetCell(row, column)
+		cell := optionTable.GetCell(row, 1)
 		if cell != nil && cell.GetReference() != nil {
 			if option, ok := cell.GetReference().(*DialogOption); ok {
 				onSelect(option)
@@ -148,13 +164,36 @@ func createOptionDialogInputCapture(
 		}
 		if event.Key() == tcell.KeyEnter {
 			row, _ := optionTable.GetSelection()
-			cell := optionTable.GetCell(row, 0)
+			cell := optionTable.GetCell(row, 1)
 			if cell != nil && cell.GetReference() != nil {
 				if option, ok := cell.GetReference().(*DialogOption); ok {
 					onSelect(option)
 				}
 			}
 			return nil
+		}
+		if event.Key() == tcell.KeyRune {
+			r := event.Rune()
+			if r >= '1' && r <= '9' {
+				targetIndex := int(r - '0')
+				optionCounter := 0
+				rowCount := optionTable.GetRowCount()
+				for row := 0; row < rowCount; row++ {
+					cell := optionTable.GetCell(row, 1)
+					if cell != nil && cell.GetReference() != nil {
+						if opt, ok := cell.GetReference().(*DialogOption); ok {
+							if opt.Id != DialogCloseActionId {
+								optionCounter++
+								if optionCounter == targetIndex {
+									optionTable.Select(row, 0)
+									return nil
+								}
+							}
+						}
+					}
+				}
+				return nil // consume digits even if out of bounds
+			}
 		}
 		return event
 	}

--- a/internal/ui/dialog/util_test.go
+++ b/internal/ui/dialog/util_test.go
@@ -1,0 +1,42 @@
+package dialog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateModal(t *testing.T) {
+	content := tview.NewBox()
+	dialog := createModal("Test Modal", content, 50, 15)
+	assert.NotNil(t, dialog)
+}
+
+func TestShowDialogOnPages(t *testing.T) {
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+	options := []*DialogOption{
+		{Id: DialogCloseActionId, Name: "Cancel"},
+	}
+	d := NewSelectionDialog(app, "test-dialog", "Title", "Desc", options)
+
+	actionHandled := false
+	handler := func(action DialogActionId) bool {
+		if action == DialogCloseActionId {
+			actionHandled = true
+			return true
+		}
+		return false
+	}
+
+	ShowDialogOnPages(app, pages, d, handler, nil)
+
+	assert.True(t, pages.HasPage("test-dialog"))
+
+	d.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	assert.True(t, actionHandled)
+}


### PR DESCRIPTION
## Description

This PR introduces comprehensive sizing, visual layout, and user experience (UX) improvements to the application's dialogs using `tview`. It resolves rigid layouts, dead spaces, text bleeding issues, and deadlocks in ZFS operation progress states, and aligns key selection flows with standard navigation shortcuts.

<img width="484" height="234" alt="image" src="https://github.com/user-attachments/assets/f55a79c5-2480-4e92-85d1-9718ffb3ad03" />

---

## Key Changes

### 1. Centralized Dynamic Dialog Auto-Sizing
- **Dynamic Size Helper**: Added a global sizing utility, `CalculateDialogSize`, inside [util.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/dialog/util.go). It queries actual terminal dimensions dynamically using `golang.org/x/term`, constraints it between defined boundaries (min-width `40`, max-width `80`), and simulates text wrapping to dynamically set the viewport width and height.
- **Widespread Integration**: Replaced hardcoded dimensions (`50`, `60`, `70`, etc.) with `CalculateDialogSize` across all UI dialogs:
  - `SelectionDialog` ([selection_dialog.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/dialog/selection_dialog.go))
  - `RestoreFileProgressDialog` ([restore_file_progress_dialog.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/dialog/restore_file_progress_dialog.go))
  - `HelpPage` ([help_dialog.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/dialog/help_dialog.go))
  - `ColumnSelectionDialog` ([column_selection_dialog.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/dialog/column_selection_dialog.go))
  - `FileDiffDialog` ([file_diff_dialog.go](file:///home/markus/GolandProjects/zfs-file-history/internal/ui/dialog/file_diff_dialog.go))

### 2. Layout Padding & Rendering Fixes
- **Flicker-Free Padding Spacer**: Replaced transparent `nil` layout spacers in `selection_dialog.go` with `tview.NewBox()` to ensure `tview` clears/redraws the background color under the description correctly, avoiding text bleeding.
- **Compact Paddings**: Restructured modal inner flex boundaries to lay out items using fixed height bounds (description height + spacer + table row count) to completely eliminate empty trailing space at the bottom of modals.
- **Help Dialog Grid Resolution**: Fixed a column alignment width bug in the Help dialog where row-by-row max width was used. Now, maximum column widths are tracked independently (left keys column vs. right descriptions column) to align the total width to the actual table grid alignment.

### 3. Selection Dialog Prefixing & Numeric Key Shortcuts
- **Grid Layout Separation**: Split the option tables into two clean columns:
  - **Left Column**: Displays right-aligned index numbers (`"1."`, `"2."`) and the `"Esc."` prefix for the cancel action. 
  - **Right Column**: Displays the option action names.
- **De-highlighted Numbers**: Styled prefix cells with `tcell.ColorGray` and custom `SelectedStyle` overrides to ensure they remain gray and do not receive the row-selection highlight background/foreground colors when focused.
- **Number Shortcuts**: Upgraded the input capture on option tables to support numeric key inputs (`'1'` to `'9'`), allowing users to instantly select/jump the selection cursor to any option.

### 4. Progress Dialog Alignment & Deadlock Prevention
- **Aligning Progress Completion**: Replaced the plain-text warning `"Press 'esc' to close"` on restore completion/error with a standard, focusable, and clickable `"Close"` option button.
- **Action Pages Container**: Used `tview.Pages` inside the progress dialog to toggle between the abort help text (`"running"`) and the `"Close"` button (`"finished"`).
- **Deadlock-Safe Async Updates**: Wrapped progress bar updates, spinner ticks, and page/focus switching logic inside `d.application.QueueUpdateDraw` to avoid data races and deadlocks between background restore worker goroutines and the main event loop.

---

## Verification Results

### Go Test Suites
All unit tests compile and pass successfully:
```bash
$ go test ./...
ok      zfs-file-history/internal/configuration (cached)
ok      zfs-file-history/internal/data          (cached)
ok      zfs-file-history/internal/profiling     (cached)
ok      zfs-file-history/internal/ui/dialog     0.013s
ok      zfs-file-history/internal/ui/file_browser (cached)
ok      zfs-file-history/internal/ui/shortcut_helper (cached)
ok      zfs-file-history/internal/ui/snapshot_browser (cached)
ok      zfs-file-history/internal/ui/status_message (cached)
ok      zfs-file-history/internal/ui/table     (cached)
ok      zfs-file-history/internal/ui/util      (cached)
ok      zfs-file-history/internal/util          (cached)
ok      zfs-file-history/internal/zfs           (cached)
```
