### PR TITLE
Feature/file history enhancements

### DIFF
--- a/internal/application.go
+++ b/internal/application.go
@@ -11,7 +11,6 @@ import (
 	"zfs-file-history/internal/ui"
 
 	"github.com/oklog/run"
-	"github.com/pterm/pterm"
 )
 
 func RunApplication(path string) {
@@ -29,7 +28,6 @@ func RunApplication(path string) {
 		os.Exit(1)
 	} else {
 		logging.Info("Done.")
-		pterm.Info.Printfln("Done.")
 		os.Exit(0)
 	}
 }
@@ -41,7 +39,6 @@ func addSignalHandlerActor(g *run.Group, cancel context.CancelFunc) {
 	g.Add(func() error {
 		<-sig
 		logging.Info("Received SIGTERM signal, exiting...")
-		pterm.Info.Printfln("Received SIGTERM signal, exiting...")
 
 		return nil
 	}, func(err error) {

--- a/internal/data/snapshot_browser_entry.go
+++ b/internal/data/snapshot_browser_entry.go
@@ -6,9 +6,10 @@ import (
 )
 
 type SnapshotBrowserEntry struct {
-	Snapshot  *zfs.Snapshot
-	DiffState diff_state.DiffState
-	IsLoading bool
+	Snapshot             *zfs.Snapshot
+	DiffState            diff_state.DiffState
+	WorkingCopyDiffState diff_state.DiffState
+	IsLoading            bool
 }
 
 func (s SnapshotBrowserEntry) TableRowId() string {

--- a/internal/ui/actor.go
+++ b/internal/ui/actor.go
@@ -24,7 +24,6 @@ func AddActor(g *run.Group, ctx context.Context, path string) {
 			pterm.Warning.Printfln("Error stopping UI: %s", err.Error())
 		} else {
 			logging.Debug("UI stopped.")
-			pterm.Debug.Printfln("Received SIGTERM signal, exiting...")
 		}
 	})
 }

--- a/internal/ui/dialog/column_selection_dialog.go
+++ b/internal/ui/dialog/column_selection_dialog.go
@@ -110,13 +110,11 @@ func (d *ColumnSelectionDialog) createLayout() {
 	extraWidth := 2 * (maxColWidth + 4)
 	staticHeight := 1 + len(d.allColumns) + 2
 
-	width, height := CalculateDialogSize(DialogSizeConstraints{
+	d.layout = createModal(d.title, content, DialogSizeConstraints{
 		Title:             d.title,
 		ExtraContentWidth: extraWidth,
 		StaticHeight:      staticHeight,
 	})
-
-	d.layout = createModal(d.title, content, width, height)
 	d.layout.SetInputCapture(d.captureInput)
 }
 

--- a/internal/ui/dialog/file_action_dialog.go
+++ b/internal/ui/dialog/file_action_dialog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"zfs-file-history/internal/data"
+	"zfs-file-history/internal/data/diff_state"
 	"zfs-file-history/internal/ui/localization"
 	"zfs-file-history/internal/ui/util"
 
@@ -54,7 +55,8 @@ func buildFileDialogOptions(file *data.FileBrowserEntry, diffBinAvailable bool) 
 		})
 	}
 
-	if file.HasSnapshot() {
+	canRestore := file.HasSnapshot() || (file.DiffState != diff_state.Equal && file.DiffState != diff_state.Unknown)
+	if canRestore {
 		if file.Type == data.Directory {
 			dialogOptions = slices.Insert(dialogOptions, 0, &DialogOption{
 				Id:       FileDialogRestoreFileActionId,

--- a/internal/ui/dialog/file_action_dialog_test.go
+++ b/internal/ui/dialog/file_action_dialog_test.go
@@ -85,9 +85,10 @@ func TestBuildFileDialogOptions_DirectoryWithSnapshot(t *testing.T) {
 
 func TestBuildFileDialogOptions_OnlyRealFile(t *testing.T) {
 	entry := &data.FileBrowserEntry{
-		Name:     "real-only.txt",
-		RealFile: &data.RealFile{Name: "real-only.txt"},
-		Type:     data.File,
+		Name:      "real-only.txt",
+		RealFile:  &data.RealFile{Name: "real-only.txt"},
+		Type:      data.File,
+		DiffState: diff_state.Unknown,
 	}
 
 	options := buildFileDialogOptions(entry, true)

--- a/internal/ui/dialog/file_diff_dialog.go
+++ b/internal/ui/dialog/file_diff_dialog.go
@@ -69,13 +69,11 @@ func (d *FileDiffDialog) createLayout() {
 	dialogContent.AddItem(closeTextView, 1, 0, false)
 	dialogContent.SetBorderPadding(0, 0, 1, 1)
 
-	width, height := CalculateDialogSize(DialogSizeConstraints{
+	dialog := createModal(dialogTitle, dialogContent, DialogSizeConstraints{
 		Title:             dialogTitle,
 		ExtraContentWidth: 74,
 		StaticHeight:      18, // Sane content height for scrollable diff text
 	})
-
-	dialog := createModal(dialogTitle, dialogContent, width, height)
 	dialog.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
 			d.Close()

--- a/internal/ui/dialog/file_history_overlay.go
+++ b/internal/ui/dialog/file_history_overlay.go
@@ -195,19 +195,36 @@ func (o *FileHistoryOverlay) createTableCells(row int, columns []*table.Column, 
 			text = entry.Snapshot.Name
 		case historyColumnDiff:
 			align = tview.AlignCenter
-			switch entry.DiffState {
-			case diff_state.Added:
-				text = "Added"
-				color = theme.Colors.SnapshotBrowser.Table.State.LocalOnly
-			case diff_state.Deleted:
-				text = "Deleted"
-				color = theme.Colors.SnapshotBrowser.Table.State.SnapshotOnly
-			case diff_state.Modified:
-				text = "Modified"
-				color = theme.Colors.SnapshotBrowser.Table.State.Modified
-			default:
-				text = "Unknown"
-				color = tcell.ColorGray
+			if o.currentDiffMode == diffModeWorkingCopy {
+				switch entry.DiffState {
+				case diff_state.Deleted:
+					text = "Present"
+					color = theme.Colors.FileBrowser.Table.State.Added
+				case diff_state.Added:
+					text = "Absent"
+					color = theme.Colors.FileBrowser.Table.State.Deleted
+				case diff_state.Modified:
+					text = "Modified"
+					color = theme.Colors.FileBrowser.Table.State.Modified
+				default:
+					text = "Identical"
+					color = theme.Colors.FileBrowser.Table.State.Equal
+				}
+			} else {
+				switch entry.DiffState {
+				case diff_state.Added:
+					text = "Added"
+					color = theme.Colors.FileBrowser.Table.State.Added
+				case diff_state.Deleted:
+					text = "Deleted"
+					color = theme.Colors.FileBrowser.Table.State.Deleted
+				case diff_state.Modified:
+					text = "Modified"
+					color = theme.Colors.FileBrowser.Table.State.Modified
+				default:
+					text = "Equal"
+					color = theme.Colors.FileBrowser.Table.State.Equal
+				}
 			}
 		case historyColumnDate:
 			text = entry.Snapshot.Properties.CreationDate.Format(theme.Style.Format.DateTime)
@@ -229,17 +246,28 @@ func (o *FileHistoryOverlay) createTableCells(row int, columns []*table.Column, 
 }
 
 func (o *FileHistoryOverlay) determineStatusColor(entry *data.SnapshotBrowserEntry) tcell.Color {
-	switch entry.DiffState {
-	case diff_state.Equal:
-		return theme.Colors.SnapshotBrowser.Table.State.Equal
-	case diff_state.Deleted:
-		return theme.Colors.SnapshotBrowser.Table.State.SnapshotOnly
-	case diff_state.Added:
-		return theme.Colors.SnapshotBrowser.Table.State.LocalOnly
-	case diff_state.Modified:
-		return theme.Colors.SnapshotBrowser.Table.State.Modified
-	default:
-		return theme.Colors.SnapshotBrowser.Table.State.Unknown
+	if o.currentDiffMode == diffModeWorkingCopy {
+		switch entry.DiffState {
+		case diff_state.Deleted:
+			return theme.Colors.FileBrowser.Table.State.Added
+		case diff_state.Added:
+			return theme.Colors.FileBrowser.Table.State.Deleted
+		case diff_state.Modified:
+			return theme.Colors.FileBrowser.Table.State.Modified
+		default:
+			return theme.Colors.FileBrowser.Table.State.Equal
+		}
+	} else {
+		switch entry.DiffState {
+		case diff_state.Added:
+			return theme.Colors.FileBrowser.Table.State.Added
+		case diff_state.Deleted:
+			return theme.Colors.FileBrowser.Table.State.Deleted
+		case diff_state.Modified:
+			return theme.Colors.FileBrowser.Table.State.Modified
+		default:
+			return theme.Colors.FileBrowser.Table.State.Equal
+		}
 	}
 }
 
@@ -418,6 +446,7 @@ func (o *FileHistoryOverlay) toggleDiffMode() {
 	o.updateModeView()
 	o.updateShortcuts()
 	o.updateDiff()
+	o.tableContainer.SetData(o.historyEntries)
 }
 
 func (o *FileHistoryOverlay) renderDiffTextSync(text string) {

--- a/internal/ui/dialog/file_history_overlay.go
+++ b/internal/ui/dialog/file_history_overlay.go
@@ -211,9 +211,14 @@ func (o *FileHistoryOverlay) createTableCells(row int, columns []*table.Column, 
 					color = theme.Colors.FileBrowser.Table.State.Equal
 				}
 			} else {
+				isOldest := len(o.historyEntries) > 0 && o.historyEntries[len(o.historyEntries)-1] == entry
 				switch entry.DiffState {
 				case diff_state.Added:
-					text = "Added"
+					if isOldest {
+						text = "Initial"
+					} else {
+						text = "Added"
+					}
 					color = theme.Colors.FileBrowser.Table.State.Added
 				case diff_state.Deleted:
 					text = "Deleted"

--- a/internal/ui/dialog/file_history_overlay.go
+++ b/internal/ui/dialog/file_history_overlay.go
@@ -685,11 +685,30 @@ func computeHistoryDiffText(oldPath, newPath string, diffMode diffMode, prevSnap
 		return "Binary files differ, content preview not available."
 	}
 
-	if diffMode == diffModeWorkingCopy {
-		_, err := os.Lstat(oldPath)
+	// Resolve missing/deleted files to DevNull for comparison
+	if oldPath != DevNull {
+		stat, err := os.Lstat(oldPath)
 		if os.IsNotExist(err) {
-			return "Working copy file does not exist (deleted)."
+			oldPath = DevNull
+		} else if err == nil && stat.IsDir() {
+			return "Directory content comparison not available."
 		}
+	}
+	if newPath != DevNull {
+		stat, err := os.Lstat(newPath)
+		if os.IsNotExist(err) {
+			newPath = DevNull
+		} else if err == nil && stat.IsDir() {
+			return "Directory content comparison not available."
+		}
+	}
+
+	// If both are missing, there's no diff content to show
+	if oldPath == DevNull && newPath == DevNull {
+		return ""
+	}
+
+	if diffMode == diffModeWorkingCopy {
 		output, err := RunDiff(oldPath, newPath)
 		if err != nil {
 			return "Error calculating diff: " + err.Error()
@@ -699,12 +718,10 @@ func computeHistoryDiffText(oldPath, newPath string, diffMode diffMode, prevSnap
 
 	// diffModePredecessor
 	if prevSnapshot == nil {
-		stat, err := os.Lstat(newPath)
-		if err != nil {
-			return "Snapshot file does not exist."
-		}
-		if stat.IsDir() {
-			return "Directory content comparison not available."
+		// Since prevSnapshot is nil, oldPath is DevNull.
+		// If newPath is also DevNull (e.g. not found), return empty
+		if newPath == DevNull {
+			return ""
 		}
 		data, err := os.ReadFile(newPath)
 		if err != nil {

--- a/internal/ui/dialog/file_history_overlay.go
+++ b/internal/ui/dialog/file_history_overlay.go
@@ -196,7 +196,7 @@ func (o *FileHistoryOverlay) createTableCells(row int, columns []*table.Column, 
 		case historyColumnDiff:
 			align = tview.AlignCenter
 			if o.currentDiffMode == diffModeWorkingCopy {
-				switch entry.DiffState {
+				switch entry.WorkingCopyDiffState {
 				case diff_state.Deleted:
 					text = "Present"
 					color = theme.Colors.FileBrowser.Table.State.Added
@@ -247,7 +247,7 @@ func (o *FileHistoryOverlay) createTableCells(row int, columns []*table.Column, 
 
 func (o *FileHistoryOverlay) determineStatusColor(entry *data.SnapshotBrowserEntry) tcell.Color {
 	if o.currentDiffMode == diffModeWorkingCopy {
-		switch entry.DiffState {
+		switch entry.WorkingCopyDiffState {
 		case diff_state.Deleted:
 			return theme.Colors.FileBrowser.Table.State.Added
 		case diff_state.Added:

--- a/internal/ui/dialog/file_history_overlay.go
+++ b/internal/ui/dialog/file_history_overlay.go
@@ -339,6 +339,23 @@ func (o *FileHistoryOverlay) createLayout() *tview.Flex {
 		AddItem(dialogContentRowWrapper, width, 1, true).
 		AddItem(nil, 0, 1, false)
 
+	dialogContentColumnWrapper.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+		screenWidth, screenHeight := screen.Size()
+		newWidth := screenWidth - 4
+		if newWidth < 80 {
+			newWidth = 80
+		}
+		newHeight := screenHeight - 2
+		if newHeight < 15 {
+			newHeight = 15
+		}
+
+		dialogContentColumnWrapper.ResizeItem(dialogContentRowWrapper, newWidth, 1)
+		dialogContentRowWrapper.ResizeItem(dialogFrame, newHeight, 1)
+
+		return x, y, width, height
+	})
+
 	return dialogContentColumnWrapper
 }
 

--- a/internal/ui/dialog/file_history_overlay.go
+++ b/internal/ui/dialog/file_history_overlay.go
@@ -339,22 +339,7 @@ func (o *FileHistoryOverlay) createLayout() *tview.Flex {
 		AddItem(dialogContentRowWrapper, width, 1, true).
 		AddItem(nil, 0, 1, false)
 
-	dialogContentColumnWrapper.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
-		screenWidth, screenHeight := screen.Size()
-		newWidth := screenWidth - 4
-		if newWidth < 80 {
-			newWidth = 80
-		}
-		newHeight := screenHeight - 2
-		if newHeight < 15 {
-			newHeight = 15
-		}
-
-		dialogContentColumnWrapper.ResizeItem(dialogContentRowWrapper, newWidth, 1)
-		dialogContentRowWrapper.ResizeItem(dialogFrame, newHeight, 1)
-
-		return x, y, width, height
-	})
+	MakeFlexResizing(dialogContentColumnWrapper, dialogContentRowWrapper, dialogFrame, 99999, 80, 99999, 15)
 
 	return dialogContentColumnWrapper
 }

--- a/internal/ui/dialog/file_history_overlay.go
+++ b/internal/ui/dialog/file_history_overlay.go
@@ -707,13 +707,23 @@ func (o *FileHistoryOverlay) restoreSelectedVersion() {
 		return
 	}
 
-	snapshotPath := entry.Snapshot.GetSnapshotPath(o.file.GetRealPath())
-	stat, err := os.Lstat(snapshotPath)
-	if err != nil {
-		logging.Error("Could not stat snapshot file %s: %s", snapshotPath, err.Error())
-		errDialog := NewErrorDialog(o.application, "Restore Failed", err)
-		ShowDialogOnPages(o.application, o.pages, errDialog, nil)
-		return
+	var stat os.FileInfo
+	var snapshotPath string
+
+	if entry.DiffState == diff_state.Deleted {
+		// File is deleted/absent in the selected snapshot.
+		snapshotPath = ""
+		stat = nil
+	} else {
+		snapshotPath = entry.Snapshot.GetSnapshotPath(o.file.GetRealPath())
+		var err error
+		stat, err = os.Lstat(snapshotPath)
+		if err != nil {
+			logging.Error("Could not stat snapshot file %s: %s", snapshotPath, err.Error())
+			errDialog := NewErrorDialog(o.application, "Restore Failed", err)
+			ShowDialogOnPages(o.application, o.pages, errDialog, nil)
+			return
+		}
 	}
 
 	snapFile := &data.SnapshotFile{

--- a/internal/ui/dialog/file_history_scanner.go
+++ b/internal/ui/dialog/file_history_scanner.go
@@ -26,20 +26,18 @@ type prefetchResult struct {
 }
 
 type historyScanner struct {
-	filePath              string
-	cachedEntries         []*data.SnapshotBrowserEntry
-	preComputedDiffStates map[string]diff_state.DiffState
-	metaCache             map[string]fileMeta
-	workingCopyExists     bool
-	workingCopyStat       os.FileInfo
+	filePath          string
+	cachedEntries     []*data.SnapshotBrowserEntry
+	metaCache         map[string]fileMeta
+	workingCopyExists bool
+	workingCopyStat   os.FileInfo
 }
 
 func newHistoryScanner(filePath string, cachedEntries []*data.SnapshotBrowserEntry) *historyScanner {
 	return &historyScanner{
-		filePath:              filePath,
-		cachedEntries:         cachedEntries,
-		preComputedDiffStates: make(map[string]diff_state.DiffState),
-		metaCache:             make(map[string]fileMeta),
+		filePath:      filePath,
+		cachedEntries: cachedEntries,
+		metaCache:     make(map[string]fileMeta),
 	}
 }
 
@@ -54,7 +52,6 @@ func (s *historyScanner) scan(loadingMsgFunc func(string)) ([]*data.SnapshotBrow
 		for _, entry := range s.cachedEntries {
 			if entry != nil && entry.Snapshot != nil {
 				snapshots = append(snapshots, entry.Snapshot)
-				s.preComputedDiffStates[entry.Snapshot.Name] = entry.DiffState
 			}
 		}
 	} else {
@@ -116,13 +113,6 @@ func (s *historyScanner) prefetchStats(snapshots []*zfs.Snapshot) {
 	var pathsToStat []string
 	for _, snap := range snapshots {
 		snapPath := snap.GetSnapshotPath(s.filePath)
-		state, ok := s.preComputedDiffStates[snap.Name]
-		if ok && state == diff_state.Equal && s.workingCopyExists {
-			continue
-		}
-		if ok && state == diff_state.Deleted {
-			continue
-		}
 		pathsToStat = append(pathsToStat, snapPath)
 	}
 
@@ -181,25 +171,6 @@ func (s *historyScanner) getSnapshotMeta(snap *zfs.Snapshot) (fileMeta, error) {
 	snapPath := snap.GetSnapshotPath(s.filePath)
 	if meta, cached := s.metaCache[snapPath]; cached {
 		return meta, nil
-	}
-
-	if state, ok := s.preComputedDiffStates[snap.Name]; ok && state != diff_state.Unknown {
-		if state == diff_state.Equal && s.workingCopyExists {
-			meta := fileMeta{
-				exists:  true,
-				isDir:   s.workingCopyStat.IsDir(),
-				size:    s.workingCopyStat.Size(),
-				mode:    s.workingCopyStat.Mode(),
-				modTime: s.workingCopyStat.ModTime(),
-			}
-			s.metaCache[snapPath] = meta
-			return meta, nil
-		}
-		if state == diff_state.Deleted {
-			meta := fileMeta{exists: false}
-			s.metaCache[snapPath] = meta
-			return meta, nil
-		}
 	}
 
 	stat, err := os.Lstat(snapPath)

--- a/internal/ui/dialog/file_history_scanner.go
+++ b/internal/ui/dialog/file_history_scanner.go
@@ -88,11 +88,19 @@ func (s *historyScanner) scan(loadingMsgFunc func(string)) ([]*data.SnapshotBrow
 			logging.Error("Failed to determine diff state between snapshots: %s", err.Error())
 			state = diff_state.Unknown
 		}
+
+		workingCopyState, err := s.determineDiffStateAgainstWorkingCopy(snap)
+		if err != nil {
+			logging.Error("Failed to determine diff state against working copy: %s", err.Error())
+			workingCopyState = diff_state.Unknown
+		}
+
 		if state != diff_state.Equal && state != diff_state.Unknown {
 			history = append(history, &data.SnapshotBrowserEntry{
-				Snapshot:  snap,
-				DiffState: state,
-				IsLoading: false,
+				Snapshot:             snap,
+				DiffState:            state,
+				WorkingCopyDiffState: workingCopyState,
+				IsLoading:            false,
 			})
 			prev = snap
 		} else if state == diff_state.Equal {
@@ -244,6 +252,31 @@ func (s *historyScanner) determineDiffStateBetween(snap, prev *zfs.Snapshot) (di
 		return diff_state.Added, nil
 	} else if prevMeta.exists {
 		return diff_state.Deleted, nil
+	}
+
+	return diff_state.Equal, nil
+}
+
+func (s *historyScanner) determineDiffStateAgainstWorkingCopy(snap *zfs.Snapshot) (diff_state.DiffState, error) {
+	sMeta, err := s.getSnapshotMeta(snap)
+	if err != nil {
+		return diff_state.Unknown, err
+	}
+
+	if sMeta.exists && s.workingCopyExists {
+		if sMeta.isDir != s.workingCopyStat.IsDir() ||
+			sMeta.size != s.workingCopyStat.Size() ||
+			sMeta.mode != s.workingCopyStat.Mode() ||
+			sMeta.modTime != s.workingCopyStat.ModTime() {
+			return diff_state.Modified, nil
+		}
+		return diff_state.Equal, nil
+	} else if sMeta.exists {
+		// File exists in snapshot, but not in working copy -> Deleted in working copy!
+		return diff_state.Deleted, nil
+	} else if s.workingCopyExists {
+		// File does not exist in snapshot, but exists in working copy -> Added in working copy!
+		return diff_state.Added, nil
 	}
 
 	return diff_state.Equal, nil

--- a/internal/ui/dialog/file_history_scanner_test.go
+++ b/internal/ui/dialog/file_history_scanner_test.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 	"zfs-file-history/internal/data/diff_state"
@@ -243,4 +244,35 @@ func TestHistoryScanner_DetermineDiffStateAgainstWorkingCopy(t *testing.T) {
 	state, err = s.determineDiffStateAgainstWorkingCopy(snap)
 	assert.NoError(t, err)
 	assert.Equal(t, diff_state.Equal, state)
+}
+
+func TestComputeHistoryDiffText(t *testing.T) {
+	tempDir := t.TempDir()
+	fileA := filepath.Join(tempDir, "fileA.txt")
+	err := os.WriteFile(fileA, []byte("Hello\nWorld\n"), 0644)
+	assert.NoError(t, err)
+
+	// Case 1: Binary
+	res := computeHistoryDiffText(fileA, fileA, diffModeWorkingCopy, nil, true)
+	assert.Equal(t, "Binary files differ, content preview not available.", res)
+
+	// Case 2: Directory comparison
+	res = computeHistoryDiffText(tempDir, fileA, diffModeWorkingCopy, nil, false)
+	assert.Equal(t, "Directory content comparison not available.", res)
+
+	// Case 3: Both missing
+	res = computeHistoryDiffText(filepath.Join(tempDir, "nonexistent1"), filepath.Join(tempDir, "nonexistent2"), diffModeWorkingCopy, nil, false)
+	assert.Equal(t, "", res)
+
+	// Case 4: Working copy exists, snapshot missing (vs working copy)
+	missingSnapPath := filepath.Join(tempDir, "missing_snap.txt")
+	res = computeHistoryDiffText(fileA, missingSnapPath, diffModeWorkingCopy, nil, false)
+	assert.Contains(t, res, "-Hello")
+	assert.Contains(t, res, "-World")
+
+	// Case 5: Working copy missing, snapshot exists (vs working copy)
+	missingWcPath := filepath.Join(tempDir, "missing_wc.txt")
+	res = computeHistoryDiffText(missingWcPath, fileA, diffModeWorkingCopy, nil, false)
+	assert.Contains(t, res, "+Hello")
+	assert.Contains(t, res, "+World")
 }

--- a/internal/ui/dialog/file_history_scanner_test.go
+++ b/internal/ui/dialog/file_history_scanner_test.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"os"
 	"testing"
 	"time"
 	"zfs-file-history/internal/data/diff_state"
@@ -155,6 +156,91 @@ func TestHistoryScanner_DetermineDiffStateBetween_PrevNil(t *testing.T) {
 	// Case 2: prev is nil, snap does not exist -> Equal
 	s.metaCache[snapPath] = fileMeta{exists: false}
 	state, err = s.determineDiffStateBetween(snap, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, diff_state.Equal, state)
+}
+
+type mockFileInfo struct {
+	isDir   bool
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+}
+
+func (m mockFileInfo) Name() string       { return "file.txt" }
+func (m mockFileInfo) Size() int64        { return m.size }
+func (m mockFileInfo) Mode() os.FileMode  { return m.mode }
+func (m mockFileInfo) ModTime() time.Time { return m.modTime }
+func (m mockFileInfo) IsDir() bool        { return m.isDir }
+func (m mockFileInfo) Sys() any           { return nil }
+
+func TestHistoryScanner_DetermineDiffStateAgainstWorkingCopy(t *testing.T) {
+	filePath := "/pool/ds1/file.txt"
+	snap := &zfs.Snapshot{
+		Name: "snap-1",
+		ParentDataset: &zfs.Dataset{
+			Path:          "/pool/ds1",
+			HiddenZfsPath: "/pool/ds1/.zfs",
+		},
+	}
+	snapPath := snap.GetSnapshotPath(filePath)
+
+	now := time.Now()
+
+	s := &historyScanner{
+		filePath:          filePath,
+		metaCache:         make(map[string]fileMeta),
+		workingCopyExists: true,
+		workingCopyStat: mockFileInfo{
+			isDir:   false,
+			size:    100,
+			mode:    0644,
+			modTime: now,
+		},
+	}
+
+	// Case 1: Snapshot exists and is equal to working copy
+	s.metaCache[snapPath] = fileMeta{
+		exists:  true,
+		isDir:   false,
+		size:    100,
+		mode:    0644,
+		modTime: now,
+	}
+	state, err := s.determineDiffStateAgainstWorkingCopy(snap)
+	assert.NoError(t, err)
+	assert.Equal(t, diff_state.Equal, state)
+
+	// Case 2: Snapshot exists but differs from working copy
+	s.metaCache[snapPath] = fileMeta{
+		exists:  true,
+		isDir:   false,
+		size:    200, // differs
+		mode:    0644,
+		modTime: now,
+	}
+	state, err = s.determineDiffStateAgainstWorkingCopy(snap)
+	assert.NoError(t, err)
+	assert.Equal(t, diff_state.Modified, state)
+
+	// Case 3: Snapshot exists, working copy does not exist
+	s.workingCopyExists = false
+	s.metaCache[snapPath] = fileMeta{exists: true}
+	state, err = s.determineDiffStateAgainstWorkingCopy(snap)
+	assert.NoError(t, err)
+	assert.Equal(t, diff_state.Deleted, state) // File only exists in snapshot, deleted in working copy
+
+	// Case 4: Snapshot does not exist, working copy exists
+	s.workingCopyExists = true
+	s.metaCache[snapPath] = fileMeta{exists: false}
+	state, err = s.determineDiffStateAgainstWorkingCopy(snap)
+	assert.NoError(t, err)
+	assert.Equal(t, diff_state.Added, state) // File only exists in working copy, added in working copy
+
+	// Case 5: Neither exists
+	s.workingCopyExists = false
+	s.metaCache[snapPath] = fileMeta{exists: false}
+	state, err = s.determineDiffStateAgainstWorkingCopy(snap)
 	assert.NoError(t, err)
 	assert.Equal(t, diff_state.Equal, state)
 }

--- a/internal/ui/dialog/help_dialog.go
+++ b/internal/ui/dialog/help_dialog.go
@@ -70,13 +70,11 @@ func (p *HelpPage) createLayout() {
 	maxHelpWidth := maxKeyWidth + 1 + maxValueWidth
 
 	title := " ℹ️ Help "
-	width, height := CalculateDialogSize(DialogSizeConstraints{
+	p.layout = createModal(title, helpTable, DialogSizeConstraints{
 		Title:             title,
 		ExtraContentWidth: maxHelpWidth,
 		StaticHeight:      len(helpTableEntries),
 	})
-
-	p.layout = createModal(title, helpTable, width, height)
 }
 
 func setHelpTableRow(helpTable *tview.Table, row int, entry *TableEntry) {

--- a/internal/ui/dialog/restore_file_progress_dialog.go
+++ b/internal/ui/dialog/restore_file_progress_dialog.go
@@ -112,13 +112,11 @@ func (d *RestoreFileProgressDialog) createLayout() {
 		AddItem(actionPages, 1, 0, false)
 	progressLayout.SetBorderPadding(0, 0, 1, 1)
 
-	width, height := CalculateDialogSize(DialogSizeConstraints{
+	dialog := createModal(dialogTitle, progressLayout, DialogSizeConstraints{
 		Title:        dialogTitle,
 		Description:  text,
 		StaticHeight: 4, // 3 for progress bar, 1 for actionPages
 	})
-
-	dialog := createModal(dialogTitle, progressLayout, width, height)
 	dialog.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
 			d.Close()

--- a/internal/ui/dialog/restore_file_progress_dialog.go
+++ b/internal/ui/dialog/restore_file_progress_dialog.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"fmt"
 	"math"
+	"os"
 	"time"
 	"zfs-file-history/internal/data"
 	"zfs-file-history/internal/logging"
@@ -157,8 +158,17 @@ func (d *RestoreFileProgressDialog) runAction(recursive bool) {
 
 		snapshotFile := d.fileSelection.SnapshotFiles[0]
 		srcFilePath := snapshotFile.Path
+		dstFilePath := snapshotFile.OriginalPath
 
-		if recursive {
+		if srcFilePath == "" {
+			// The file is absent in the snapshot.
+			// Restoring it means deleting the working copy!
+			err := os.RemoveAll(dstFilePath)
+			d.handleError(err)
+			if err != nil {
+				return
+			}
+		} else if recursive {
 			// TODO: this loops two times currently to ensure folder modtime properties are correct.
 			//  See implementation for what we need to do to fix this
 			for i := 0; i < 2; i++ {

--- a/internal/ui/dialog/restore_file_progress_dialog_test.go
+++ b/internal/ui/dialog/restore_file_progress_dialog_test.go
@@ -1,6 +1,8 @@
 package dialog
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 	"zfs-file-history/internal/data"
@@ -38,4 +40,38 @@ func TestRestoreFileProgressDialog(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	d.Close()
+}
+
+func TestRestoreFileProgressDialog_AbsentFile(t *testing.T) {
+	app := tview.NewApplication()
+	tempFile := filepath.Join(t.TempDir(), "to_delete.txt")
+	err := os.WriteFile(tempFile, []byte("hello"), 0644)
+	assert.NoError(t, err)
+
+	file := &data.FileBrowserEntry{
+		Name: "to_delete.txt",
+		SnapshotFiles: []*data.SnapshotFile{
+			{
+				Path:         "", // empty path means absent in snapshot
+				OriginalPath: tempFile,
+				Snapshot: &zfs.Snapshot{
+					Name: "snap1",
+					ParentDataset: &zfs.Dataset{
+						Path:          "/pool/ds1",
+						HiddenZfsPath: "/pool/ds1/.zfs",
+					},
+				},
+			},
+		},
+	}
+
+	d := NewRestoreFileProgressDialog(app, file, false)
+	assert.Equal(t, string(RestoreFileProgress), d.GetName())
+
+	time.Sleep(100 * time.Millisecond)
+
+	d.Close()
+
+	// Assert the working copy was deleted
+	assert.NoFileExists(t, tempFile)
 }

--- a/internal/ui/dialog/selection_dialog.go
+++ b/internal/ui/dialog/selection_dialog.go
@@ -78,12 +78,14 @@ func (d *SelectionDialog) createLayout() {
 		}
 	}
 
-	dialogWidth, dialogHeight := CalculateDialogSize(DialogSizeConstraints{
+	constraints := DialogSizeConstraints{
 		Title:             d.title,
 		Description:       d.description,
 		ExtraContentWidth: maxOptWidth,
 		StaticHeight:      1 + actualTableRows,
-	})
+	}
+
+	dialogWidth, _ := CalculateDialogSize(constraints)
 
 	textLineWidth := dialogWidth - 6
 	if textLineWidth < 5 {
@@ -103,7 +105,7 @@ func (d *SelectionDialog) createLayout() {
 	dialogContent.AddItem(tview.NewBox(), 1, 0, false)
 	dialogContent.AddItem(d.optionTable, actualTableRows, 0, true)
 
-	dialog := createModal(d.title, dialogContent, dialogWidth, dialogHeight)
+	dialog := createModal(d.title, dialogContent, constraints)
 	dialog.SetInputCapture(createOptionDialogInputCapture(d.optionTable, d.options, d.selectAction, d.Close))
 	d.layout = dialog
 }

--- a/internal/ui/dialog/util.go
+++ b/internal/ui/dialog/util.go
@@ -117,10 +117,33 @@ func createModal(title string, content tview.Primitive, constraints DialogSizeCo
 		AddItem(nil, 0, 1, false)
 
 	dialogContentColumnWrapper.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+		screenWidth, screenHeight := screen.Size()
 		w, h := CalculateDialogSize(constraints)
+
+		// Center the modal on top of the view it is associated with (defined by x, y, width, height)
+		dx := x + (width-w)/2
+		dy := y + (height-h)/2
+
+		// Ensure the dialog stays completely within available terminal screen bounds
+		if dx < 0 {
+			dx = 0
+		}
+		if dx+w > screenWidth {
+			dx = screenWidth - w
+		}
+		if dy < 0 {
+			dy = 0
+		}
+		if dy+h > screenHeight {
+			dy = screenHeight - h
+		}
+
 		dialogContentColumnWrapper.ResizeItem(dialogContentRowWrapper, w, 1)
 		dialogContentRowWrapper.ResizeItem(dialogFrame, h, 1)
-		return x, y, width, height
+
+		dialogContentColumnWrapper.SetRect(dx, dy, w, h)
+
+		return dx, dy, w, h
 	})
 
 	return dialogContentColumnWrapper

--- a/internal/ui/dialog/util.go
+++ b/internal/ui/dialog/util.go
@@ -64,8 +64,41 @@ func buildConfirmDialogOptions(
 	return options
 }
 
+// MakeFlexResizing registers a SetDrawFunc resize handler on columnWrapper
+// to dynamically resize rowWrapper and dialogFrame based on terminal size and constraints.
+func MakeFlexResizing(
+	columnWrapper *tview.Flex,
+	rowWrapper *tview.Flex,
+	dialogFrame *tview.Flex,
+	targetWidth, minWidth int,
+	targetHeight, minHeight int,
+) {
+	columnWrapper.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+		screenWidth, screenHeight := screen.Size()
+		w := targetWidth
+		if w > screenWidth-4 {
+			w = screenWidth - 4
+		}
+		if w < minWidth {
+			w = minWidth
+		}
+		h := targetHeight
+		if h > screenHeight-2 {
+			h = screenHeight - 2
+		}
+		if h < minHeight {
+			h = minHeight
+		}
+
+		columnWrapper.ResizeItem(rowWrapper, w, 1)
+		rowWrapper.ResizeItem(dialogFrame, h, 1)
+
+		return x, y, width, height
+	})
+}
+
 // createModal creates a [tview.Flex] layout for a modal dialog with the given title and content.
-func createModal(title string, content tview.Primitive, width int, height int) *tview.Flex {
+func createModal(title string, content tview.Primitive, constraints DialogSizeConstraints) *tview.Flex {
 	dialogFrame := tview.NewFlex()
 	dialogFrame.SetBorder(true)
 	uiutil.SetupDialogWindow(dialogFrame, title)
@@ -76,12 +109,19 @@ func createModal(title string, content tview.Primitive, width int, height int) *
 
 	dialogContentRowWrapper := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(nil, 0, 1, false).
-		AddItem(dialogFrame, height, 1, true).
+		AddItem(dialogFrame, 0, 1, true).
 		AddItem(nil, 0, 1, false)
 
 	dialogContentColumnWrapper.
-		AddItem(dialogContentRowWrapper, width, 1, true).
+		AddItem(dialogContentRowWrapper, 0, 1, true).
 		AddItem(nil, 0, 1, false)
+
+	dialogContentColumnWrapper.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+		w, h := CalculateDialogSize(constraints)
+		dialogContentColumnWrapper.ResizeItem(dialogContentRowWrapper, w, 1)
+		dialogContentRowWrapper.ResizeItem(dialogFrame, h, 1)
+		return x, y, width, height
+	})
 
 	return dialogContentColumnWrapper
 }

--- a/internal/ui/dialog/util_test.go
+++ b/internal/ui/dialog/util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,6 +16,35 @@ func TestCreateModal(t *testing.T) {
 		StaticHeight: 15,
 	})
 	assert.NotNil(t, dialog)
+}
+
+func TestCreateModal_Clamping(t *testing.T) {
+	content := tview.NewBox()
+	dialog := createModal("Test Modal", content, DialogSizeConstraints{
+		Title:             "Test Modal",
+		ExtraContentWidth: 60,
+		StaticHeight:      10,
+	})
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	err := screen.Init()
+	assert.NoError(t, err)
+	defer screen.Fini()
+
+	screen.SetSize(80, 24)
+
+	// Set rect simulating it's mounted on an offset sub-view at x=60, width=20
+	dialog.SetRect(60, 5, 20, 10)
+
+	dialog.Draw(screen)
+
+	x, _, w, _ := dialog.GetRect()
+
+	// Expected dialog width: maxContentWidth (60) + 6 = 66
+	// Centering relative to offset sub-view: 60 + (20-66)/2 = 37.
+	// Since 37 + 66 = 103 > 80 (screenWidth), it must clamp to screenWidth - w = 14!
+	assert.Equal(t, 14, x)
+	assert.Equal(t, 66, w)
 }
 
 func TestShowDialogOnPages(t *testing.T) {

--- a/internal/ui/dialog/util_test.go
+++ b/internal/ui/dialog/util_test.go
@@ -10,7 +10,10 @@ import (
 
 func TestCreateModal(t *testing.T) {
 	content := tview.NewBox()
-	dialog := createModal("Test Modal", content, 50, 15)
+	dialog := createModal("Test Modal", content, DialogSizeConstraints{
+		Title:        "Test Modal",
+		StaticHeight: 15,
+	})
 	assert.NotNil(t, dialog)
 }
 

--- a/internal/ui/file_browser/file_browser.go
+++ b/internal/ui/file_browser/file_browser.go
@@ -508,7 +508,11 @@ func (fileBrowser *FileBrowserComponent) openDeleteDialog(selection *data.FileBr
 	fileBrowser.showDialog(deleteDialog, nil) // nil for the onUpdate callback
 }
 func (fileBrowser *FileBrowserComponent) openRestoreDialog(selection *data.FileBrowserEntry) {
-	if selection == nil || !selection.HasSnapshot() {
+	if selection == nil {
+		return
+	}
+	canRestore := selection.HasSnapshot() || (selection.DiffState != diff_state.Equal && selection.DiffState != diff_state.Unknown)
+	if !canRestore {
 		return
 	}
 
@@ -867,6 +871,17 @@ func (fileBrowser *FileBrowserComponent) enterFileEntry(selection *data.FileBrow
 }
 
 func (fileBrowser *FileBrowserComponent) runRestoreFileAction(entry *data.FileBrowserEntry, recursive bool) error {
+	// If the file is absent in the snapshot, create a dummy SnapshotFile referencing the current snapshot.
+	if len(entry.SnapshotFiles) == 0 && fileBrowser.currentSnapshot != nil {
+		entry.SnapshotFiles = []*data.SnapshotFile{
+			{
+				Path:         "", // empty path indicates absent in snapshot
+				OriginalPath: entry.GetRealPath(),
+				Snapshot:     fileBrowser.currentSnapshot.Snapshot,
+			},
+		}
+	}
+
 	d := dialog.NewRestoreFileProgressDialog(fileBrowser.application, entry, recursive)
 
 	// Pass the refresh logic as the onUpdate callback.


### PR DESCRIPTION
Unified Modal Layout Sizing, Context-Aware Diff Coloring & Absent Snapshot Restoration Support

This pull request introduces clean terminal layout abstractions, corrects snapshot diff calculations, aligns coloring conventions with standard git/diff tools, supports restoring absent files (removing them locally), and silences exit sequence printing.


<img width="1920" height="640" alt="image" src="https://github.com/user-attachments/assets/d49b117c-2448-4af0-8d47-47bff67dfce0" />

<img width="1536" height="640" alt="image" src="https://github.com/user-attachments/assets/b01c384c-843b-4edd-8c1b-6397af7eb3de" />

---

## Key Features & Refactorings

### 1. Unified Dialog & Modal Auto-Resizing
* **Abstracted Resizing Engine**: Created a reusable `MakeFlexResizing` layout helper in `internal/ui/dialog/util.go`. It intercepts draw events on the outer flex wrapper, checks the terminal size, and dynamically resizes child wrappers to target dimensions while respecting minimum bounds.
* **Constraints-Driven Modals**: Refactored `createModal` to accept a `DialogSizeConstraints` struct. Rather than hardcoding dimensions at startup, modals now recalculate sizing constraints dynamically on every frame draw, allowing all standard popups to adaptively resize when the terminal is resized.
* **Overlay Resize Integration**: Updated `file_history_overlay.go` to use the new `MakeFlexResizing` helper, ensuring the complex history layout fills the terminal space smoothly and resizes dynamically.
* **Simplified Call Sites**: Migrated all callers to pass constraints directly to `createModal`, eliminating manual `CalculateDialogSize` pre-calculations across:
  * `column_selection_dialog.go`
  * `file_diff_dialog.go`
  * `help_dialog.go`
  * `restore_file_progress_dialog.go`
  * `selection_dialog.go`
  * `util_test.go`

### 2. Disentangled Working Copy vs. Predecessor Diff Calculations
* **Separated State Tracking**: Added a new `WorkingCopyDiffState` field to `SnapshotBrowserEntry` to prevent collision with predecessor diff states.
* **Dedicated Working Copy Diff Evaluator**: Implemented `determineDiffStateAgainstWorkingCopy` in `file_history_scanner.go` to calculate snapshot files vs. the live working copy on the system.
* **Removed State-Mapping Caching Bugs**: Removed the faulty `preComputedDiffStates` caching optimization in the scanner. The scanner now cleanly stats the snapshots (benefiting from parallel prefetching) to avoid incorrectly treating snapshot files as absent because of working copy states.
* **Context-Aware Color Convention & Terminology**:
  * Corrected green/red inversion in predecessor view (Added = Green, Deleted = Red).
  * Implemented dynamic label and color mapping for "vs Working Copy" mode:
    * **Present** (exists in snapshot, missing locally): Green (can be restored).
    * **Absent** (missing in snapshot, exists locally): Red (restoring will remove local file).
    * **Modified**: Yellow.
    * **Identical**: Gray.
  * Added oldest entry detection in predecessor mode to render `"Initial"` instead of `"Added"` (since there is no predecessor).

### 3. Restoration Support for Absent/Deleted Snapshots
* **Bypassed Immediate Stat Checks**: Bypassed `os.Lstat` checks in `file_history_overlay.go` for snapshots where the file is deleted. This allows the user to open the action confirmation dialog successfully instead of failing immediately with a "Restore Failed" popup.
* **Restoration by Local Deletion**: Enabled the "Restore" option for absent snapshots in the file browser. If a file is absent in the snapshot, the restoration progress logic (`restore_file_progress_dialog.go`) now deletes the local working copy copy using `os.RemoveAll` to align with the snapshot.
* **Added Unit Tests**: Wrote `TestRestoreFileProgressDialog_AbsentFile` validating that restoring a file absent in a snapshot correctly deletes the local copy.

### 4. Silenced SIGTERM and Done Exit Prints
* **Clean Terminal Output**: Removed noisy `pterm` exit status messages from stdout/stderr on exit (`application.go`, `actor.go`).
* **Preserved Silent Diagnostics**: Retained internal `logging.Info`/`logging.Debug` calls to ensure clean exit paths are still captured in `zfs-file-history.log`.

---

## Verification
* Run unit tests: `go test -v ./...` (All checks pass with high coverage)
* Rebuild package: `just build` (Binary compiles successfully and operates correctly)
